### PR TITLE
remotedata globalpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,5 @@ build-backend = 'setuptools.build_meta'
 filterwarnings = [
     'ignore:may indicate binary incompatibility:RuntimeWarning',
 ]
+log_cli = true
+log_cli_level = "DEBUG"

--- a/pysm3/tests/test_utils.py
+++ b/pysm3/tests/test_utils.py
@@ -58,14 +58,12 @@ def test_bandpass_integration_weights():
     np.testing.assert_allclose(input_map, output_map)
 
 
-def test_remotedata(tmp_path):
-    import os
-
+def test_remotedata(tmp_path, monkeypatch):
     data_folder = tmp_path / "data"
     data_folder.mkdir()
     test_file = data_folder / "testfile.txt"
     test_file.touch()
-    os.environ["PYSM_LOCAL_DATA"] = str(data_folder)
+    monkeypatch.setenv("PYSM_LOCAL_DATA", str(data_folder))
     filename = pysm3.utils.RemoteData().get("testfile.txt")
     assert filename == str(test_file)
 

--- a/pysm3/tests/test_utils.py
+++ b/pysm3/tests/test_utils.py
@@ -68,3 +68,12 @@ def test_remotedata(tmp_path):
     os.environ["PYSM_LOCAL_DATA"] = str(data_folder)
     filename = pysm3.utils.RemoteData().get("testfile.txt")
     assert filename == str(test_file)
+
+
+def test_remotedata_globalpath(tmp_path):
+    data_folder = tmp_path / "data"
+    data_folder.mkdir()
+    test_file = data_folder / "testfile.txt"
+    test_file.touch()
+    filename = pysm3.utils.RemoteData().get(str(test_file))
+    assert filename == str(test_file)

--- a/pysm3/tests/test_utils.py
+++ b/pysm3/tests/test_utils.py
@@ -56,3 +56,15 @@ def test_bandpass_integration_weights():
     for i, (freq, weight) in enumerate(zip(freqs, weights)):
         utils.trapz_step_inplace(freqs, weights, i, input_map, output_map)
     np.testing.assert_allclose(input_map, output_map)
+
+
+def test_remotedata(tmp_path):
+    import os
+
+    data_folder = tmp_path / "data"
+    data_folder.mkdir()
+    test_file = data_folder / "testfile.txt"
+    test_file.touch()
+    os.environ["PYSM_LOCAL_DATA"] = str(data_folder)
+    filename = pysm3.utils.RemoteData().get("testfile.txt")
+    assert filename == str(test_file)


### PR DESCRIPTION
- test: implement unit test for remotedata
- test: enable logging in pytest
- run test with global path
