### PR TITLE
[patch] websky radio galaxy units

### DIFF
--- a/pysm3/models/websky.py
+++ b/pysm3/models/websky.py
@@ -178,7 +178,7 @@ class WebSkyRadioGalaxies(WebSkyCIB):
         self,
         nside,
         websky_version="0.4",
-        input_units="MJy / sr",
+        input_units="Jy / sr",
         max_nside=4096,
         interpolation_kind="linear",
         apply_SPT_correction=False,


### PR DESCRIPTION
This PR removes a single character. The WebSky radio galaxy maps were released as Jy/sr, while the CIB maps were released as MJy/sr. Due to copy-pasting the constructor kwargs, I had both components have input units of MJy/sr.

@zonca @giuspugl sorry about this bug, it evaded by various validation tests. I should have validated on the muK^2 output maps. This should resolve some of your radio source ringing issues, by suppressing them by a factor of a million.

I actually have generated maps smoothed in real space by a 0.9 arcminute Gaussian beam available on perlmutter, but I need to write up an interface somehow. Perhaps just a totally different component?
