### PR TITLE
make sure model evaluation is done in double precision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 3.4.1 (unreleased)
 ==================
+- Make sure models are evaluated in double precision https://github.com/galsci/pysm/pull/196
 - Fix bug in `cib1` when frequency goes below 18.7 GHz, emission too large https://github.com/galsci/pysm/pull/195
 - Finalized Point Source Catalog component and backgroud component https://github.com/galsci/pysm/pull/191
 - Configure verbosity easily with `set_verbosity()`

--- a/src/pysm3/models/cmb.py
+++ b/src/pysm3/models/cmb.py
@@ -54,7 +54,7 @@ class CMBMap(Model):
         # do not use normalize weights because that includes a transformation
         # to spectral radiance and then back to RJ
         if weights is None:
-            weights = np.ones(len(freqs), dtype=np.float32)
+            weights = np.ones(len(freqs), dtype=np.float64)
 
         scaling_factor = utils.bandpass_unit_conversion(
             freqs * u.GHz, weights, output_unit=u.uK_RJ, input_unit=u.uK_CMB

--- a/src/pysm3/models/co_lines.py
+++ b/src/pysm3/models/co_lines.py
@@ -129,7 +129,7 @@ class COLines(Model):
     ) -> u.Quantity[u.uK_RJ]:
         freqs = utils.check_freq_input(freqs)
         weights = utils.normalize_weights(freqs, weights)
-        out = np.zeros((3, hp.nside2npix(self.nside)), dtype=np.double)
+        out = np.zeros((3, hp.nside2npix(self.nside)), dtype=np.float64)
         for line in self.lines:
             line_freq = self.line_frequency[line].to_value(u.GHz)
             if line_freq >= freqs[0] and line_freq <= freqs[-1]:

--- a/src/pysm3/models/dust.py
+++ b/src/pysm3/models/dust.py
@@ -144,8 +144,8 @@ def get_emission_numba(
     mbb_index,
     mbb_temperature,
 ):
-    output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
-    temp = np.zeros((3, len(I_ref)), dtype=I_ref.dtype) if len(freqs) > 1 else output
+    output = np.zeros((3, len(I_ref)), dtype=np.float64)
+    temp = np.zeros((3, len(I_ref)), dtype=np.float64) if len(freqs) > 1 else output
 
     I, Q, U = 0, 1, 2
     for i, (freq, _weight) in enumerate(zip(freqs, weights)):
@@ -154,11 +154,13 @@ def get_emission_numba(
         temp[U, :] = U_ref
         if freq != freq_ref_I:
             # -2 because black body is in flux unit and not K_RJ
-            temp[I] *= (freq / freq_ref_I) ** (mbb_index - 2.0)
-            temp[I] *= blackbody_ratio(freq, freq_ref_I, mbb_temperature)
-            freq_scaling_P = (freq / freq_ref_P) ** (mbb_index - 2.0) * blackbody_ratio(
-                freq, freq_ref_P, mbb_temperature
+            temp[I] *= (np.float64(freq / freq_ref_I)) ** (mbb_index - 2.0)
+            temp[I] *= blackbody_ratio(
+                np.float64(freq), np.float64(freq_ref_I), mbb_temperature
             )
+            freq_scaling_P = (np.float64(freq / freq_ref_P)) ** (
+                mbb_index - 2.0
+            ) * blackbody_ratio(np.float64(freq), np.float64(freq_ref_P), mbb_temperature)
             for P in [Q, U]:
                 temp[P] *= freq_scaling_P
         if len(freqs) > 1:

--- a/src/pysm3/models/dust_layers.py
+++ b/src/pysm3/models/dust_layers.py
@@ -131,8 +131,8 @@ def get_emission_numba(
     mbb_temperature,
 ):
     npix = layers.shape[-1]
-    output = np.zeros((3, npix), dtype=layers.dtype)
-    temp = np.zeros((3, npix), dtype=layers.dtype)
+    output = np.zeros((3, npix), dtype=np.float64)
+    temp = np.zeros((3, npix), dtype=np.float64)
 
     I, Q, U = 0, 1, 2
     for i, (freq, _weight) in enumerate(zip(freqs, weights)):

--- a/src/pysm3/models/power_law.py
+++ b/src/pysm3/models/power_law.py
@@ -132,14 +132,18 @@ def get_emission_numba_IQU(
     freqs, weights, I_ref, Q_ref, U_ref, freq_ref_I, freq_ref_P, pl_index
 ):
     has_pol = Q_ref is not None
-    output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
+    output = np.zeros((3, len(I_ref)), dtype=np.float64)
     I, Q, U = 0, 1, 2
     for i, (freq, _weight) in enumerate(zip(freqs, weights)):
         utils.trapz_step_inplace(
-            freqs, weights, i, I_ref * (freq / freq_ref_I) ** pl_index, output[I]
+            freqs,
+            weights,
+            i,
+            I_ref.astype(np.float64) * (np.float64(freq) / freq_ref_I) ** pl_index,
+            output[I],
         )
         if has_pol:
-            pol_scaling = (freq / freq_ref_P) ** pl_index
+            pol_scaling = (np.float64(freq) / freq_ref_P) ** pl_index
             utils.trapz_step_inplace(freqs, weights, i, Q_ref * pol_scaling, output[Q])
             utils.trapz_step_inplace(freqs, weights, i, U_ref * pol_scaling, output[U])
     return output
@@ -240,19 +244,19 @@ def get_emission_numba_IQU_curved(
     curvature,
 ):
     has_pol = Q_ref is not None
-    output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
+    output = np.zeros((3, len(I_ref)), dtype=np.float64)
     I, Q, U = 0, 1, 2
     for i, (freq, _weight) in enumerate(zip(freqs, weights)):
-        curvature_term = np.log((freq / freq_curve) ** curvature)
+        curvature_term = np.log((np.float64(freq) / freq_curve) ** curvature)
         utils.trapz_step_inplace(
             freqs,
             weights,
             i,
-            I_ref * (freq / freq_ref_I) ** (pl_index + curvature_term),
+            I_ref * (np.float64(freq) / freq_ref_I) ** (pl_index + curvature_term),
             output[I],
         )
         if has_pol:
-            pol_scaling = (freq / freq_ref_P) ** (pl_index + curvature_term)
+            pol_scaling = (np.float64(freq) / freq_ref_P) ** (pl_index + curvature_term)
             utils.trapz_step_inplace(freqs, weights, i, Q_ref * pol_scaling, output[Q])
             utils.trapz_step_inplace(freqs, weights, i, U_ref * pol_scaling, output[U])
     return output

--- a/src/pysm3/models/spdust.py
+++ b/src/pysm3/models/spdust.py
@@ -97,9 +97,14 @@ def compute_spdust_scaling_numba(freq, freq_ref_I, freq_peak, emissivity):
 def compute_spdust_emission_numba(
     freqs, weights, I_ref, freq_ref_I, freq_peak, emissivity
 ):
-    output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
+    output = np.zeros((3, len(I_ref)), dtype=np.float64)
     for i, (freq, _weight) in enumerate(zip(freqs, weights)):
-        scaling = compute_spdust_scaling_numba(freq, freq_ref_I, freq_peak, emissivity)
+        scaling = compute_spdust_scaling_numba(
+            freq,
+            freq_ref_I,
+            freq_peak,
+            emissivity.astype(np.float64),
+        )
         utils.trapz_step_inplace(freqs, weights, i, scaling * I_ref, output[0])
     return output
 
@@ -162,7 +167,12 @@ def compute_spdust_emission_pol_numba(
     output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
     I, Q, U = 0, 1, 2
     for i, (freq, _weight) in enumerate(zip(freqs, weights)):
-        scaling = compute_spdust_scaling_numba(freq, freq_ref_I, freq_peak, emissivity)
+        scaling = compute_spdust_scaling_numba(
+            freq,
+            freq_ref_I,
+            freq_peak,
+            emissivity.astype(np.float64),
+        )
         utils.trapz_step_inplace(freqs, weights, i, scaling * I_ref, output[I])
         utils.trapz_step_inplace(
             freqs, weights, i, scaling * I_ref * pol_frac * np.cos(pol_angle), output[Q]

--- a/src/pysm3/models/websky.py
+++ b/src/pysm3/models/websky.py
@@ -277,9 +277,9 @@ class WebSkySZ(Model):
 
 @njit(parallel=True)
 def get_sz_emission_numba(freqs, weights, m, is_thermal):
-    output = np.zeros((3, len(m)), dtype=m.dtype)
+    output = np.zeros((3, len(m)), dtype=np.float64)
     for i in range(len(freqs)):
-        signal = m * m.dtype.type(y2uK_CMB(freqs[i])) if is_thermal else m
+        signal = m * y2uK_CMB(freqs[i]) if is_thermal else m.astype(np.float64)
         pysm.utils.trapz_step_inplace(freqs, weights, i, signal, output[0])
     return output
 


### PR DESCRIPTION
Often the input maps are in float32, in order to save memory is a good idea to keep them in memory also at float32.

However, as soon as we want to evaluate the model and then bandpass integrate, we want to make sure they are executed in double precision so we avoid accumulating rounding errors.
