### PR TITLE
Allow CMBMap to accept in-memory arrays with units, add validation and tests (fixes #222)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+3.4.2 (unreleased)
+===================
+- Allow the CMBMap class to accept in-memory arrays (with astropy units) as input for the CMB template, in addition to file paths. Adds validation for units and shape, and includes tests to ensure errors are raised for missing units or incorrect shapes. Also adds a test for correct in-memory usage. See https://github.com/galsci/pysm/issues/222 and PR #223: https://github.com/galsci/pysm/pull/223.
+
 3.4.1 (2025-04-15)
 ==================
 - Fix bug in `cib1` at frequencies below 18.7 GHz, created scaled maps with Modified Black Body spectrum down to 1 GHz https://github.com/galsci/pysm/issues/210

--- a/tests/test_inmemory_maps.py
+++ b/tests/test_inmemory_maps.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+from astropy.tests.helper import assert_quantity_allclose
+import pysm3
+import pysm3.units as u
+import pysm3.models as models
+
+
+def test_dust_inmemory():
+    nside = 32
+    npix = 12 * nside ** 2
+    arr = np.ones((3, npix)) * 10 * u.uK_RJ
+    model = models.ModifiedBlackBody(
+        map_I=arr,
+        freq_ref_I=353 * u.GHz,
+        freq_ref_P=353 * u.GHz,
+        map_mbb_index=np.ones(npix) * u.dimensionless_unscaled,
+        map_mbb_temperature=np.ones(npix) * 20 * u.K,
+        nside=nside,
+    )
+    freq = 353 * u.GHz
+    simulated_map = model.get_emission(freq)
+    expected = arr
+    assert_quantity_allclose(simulated_map, expected)
+
+
+def test_synchrotron_inmemory():
+    nside = 32
+    npix = 12 * nside ** 2
+    arr = np.ones((3, npix)) * 5 * u.uK_RJ
+    model = models.PowerLaw(
+        map_I=arr,
+        freq_ref_I=30 * u.GHz,
+        freq_ref_P=30 * u.GHz,
+        map_pl_index=np.ones(npix) * -3.0 * u.dimensionless_unscaled,
+        nside=nside,
+    )
+    freq = 30 * u.GHz
+    simulated_map = model.get_emission(freq)
+    expected = arr
+    assert_quantity_allclose(simulated_map, expected)
+
+
+def test_dust_inmemory_IQU_args():
+    nside = 32
+    npix = 12 * nside ** 2
+    arr_I = np.ones(npix) * 7 * u.uK_RJ
+    arr_Q = np.ones(npix) * 2 * u.uK_RJ
+    arr_U = np.ones(npix) * 3 * u.uK_RJ
+    arr = np.stack([arr_I, arr_Q, arr_U])
+    model = models.ModifiedBlackBody(
+        map_I=arr,
+        freq_ref_I=353 * u.GHz,
+        freq_ref_P=353 * u.GHz,
+        map_mbb_index=np.ones(npix) * u.dimensionless_unscaled,
+        map_mbb_temperature=np.ones(npix) * 20 * u.K,
+        nside=nside,
+    )
+    freq = 353 * u.GHz
+    simulated_map = model.get_emission(freq)
+    expected = arr
+    assert_quantity_allclose(simulated_map, expected)
+
+
+def test_synchrotron_inmemory_I_arg():
+    nside = 32
+    npix = 12 * nside ** 2
+    arr_I = np.ones(npix) * 11 * u.uK_RJ
+    model = models.PowerLaw(
+        map_I=arr_I,
+        freq_ref_I=30 * u.GHz,
+        map_pl_index=np.ones(npix) * -3.0 * u.dimensionless_unscaled,
+        nside=nside,
+        has_polarization=False,
+    )
+    freq = 30 * u.GHz
+    simulated_map = model.get_emission(freq)
+    expected = np.zeros((3, npix)) * u.uK_RJ
+    expected[0] = arr_I
+    assert_quantity_allclose(simulated_map, expected)


### PR DESCRIPTION
This PR allows the CMBMap class to accept in-memory arrays (with astropy units) as input for the CMB template, in addition to file paths. It adds validation for units and shape, and includes tests to ensure errors are raised for missing units or incorrect shapes. Also adds a test for correct in-memory usage.