### PR TITLE
Update PySM references to published PanEx ApJ paper

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,11 +1,13 @@
 @article{Panexp_2025,
-      title={Full-sky Models of Galactic Microwave Emission and Polarization at Sub-arcminute Scales for the Python Sky Model}, 
-      author={Pan-Experiment Galactic Science Group and Julian Borrill and Susan E. Clark and Jacques Delabrouille and Andrei V. Frolov and Shamik Ghosh and Brandon S. Hensley and Monica D. Hicks and Nicoletta Krachmalnicoff and King Lau and Myra M. Norton and Clement Pryke and Giuseppe Puglisi and Mathieu Remazeilles and Elisa Russier and Benjamin Thorne and Jian Yao and Andrea Zonca},
-      year={2025},
-      eprint={2502.20452},
-      archivePrefix={arXiv},
-      primaryClass={astro-ph.CO},
-      url={https://arxiv.org/abs/2502.20452}, 
+  title={Full-sky Models of Galactic Microwave Emission and Polarization at Subarcminute Scales for the Python Sky Model},
+  author={The Pan-Experiment Galactic Science Group and Julian Borrill and Susan E. Clark and Jacques Delabrouille and Andrei V. Frolov and Shamik Ghosh and Brandon S. Hensley and Monica D. Hicks and Nicoletta Krachmalnicoff and King Lau and Myra M. Norton and Clement Pryke and Giuseppe Puglisi and Mathieu Remazeilles and Elisa Russier and Benjamin Thorne and Jian Yao and Andrea Zonca},
+  year={2025},
+  journal={The Astrophysical Journal},
+  volume={991},
+  number={1},
+  pages={23},
+  doi={10.3847/1538-4357/adf212},
+  url={https://iopscience.iop.org/article/10.3847/1538-4357/adf212}
 }
 
 @article{Zonca_2021,

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Related scientific papers
 
 See `CITATION <https://github.com/galsci/pysm/blob/main/CITATION>`_
 
-* `Full-sky Models of Galactic Microwave Emission and Polarization (Pan-Experiment Galactic Science Group, 2025) <https://arxiv.org/abs/2502.20452>`_
+* `Full-sky Models of Galactic Microwave Emission and Polarization at Subarcminute Scales for the Python Sky Model (The PanEx GS Group, ApJ 991, 23, 2025) <https://iopscience.iop.org/article/10.3847/1538-4357/adf212>`_
 * `The Python Sky Model 3 software (Zonca et al, 2021) <https://arxiv.org/abs/2108.01444>`_
 * `The Python Sky Model: software for simulating the Galactic microwave sky (Thorne et al, 2017) <https://arxiv.org/abs/1608.02841>`_
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ If you are using this code please cite:
 
 * `The Python Sky Model: software for simulating the Galactic microwave sky (Thorne et al, 2017) <https://arxiv.org/abs/1608.02841>`_
 * `The Python Sky Model 3 software (Zonca et al, 2021) <https://arxiv.org/abs/2108.01444>`_
-* `Full-Sky Models of Galactic Microwave Emission and Polarization at Sub-arcminute Scales for the Python Sky Model (The PanEx GS Group, submitted to ApJ) <https://arxiv.org/abs/2502.20452>`_  :doc:`Author contributions statement <pysm_methods_author_contributions>`.
+* `Full-sky Models of Galactic Microwave Emission and Polarization at Subarcminute Scales for the Python Sky Model (The PanEx GS Group, ApJ 991, 23, 2025) <https://iopscience.iop.org/article/10.3847/1538-4357/adf212>`_  :doc:`Author contributions statement <pysm_methods_author_contributions>`.
 
 See the Bibtex format file `CITATION <https://github.com/galsci/pysm/blob/main/CITATION>`_
 


### PR DESCRIPTION
## Summary
- switch CITATION entry for the PanEx foregrounds paper to the ApJ publication with DOI 10.3847/1538-4357/adf212
- update docs, README links that still pointed to the arXiv preprint

## Testing
- not run (docs-only change)