### PR TITLE
docs: clean up release workflow and Sphinx warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,11 +42,41 @@ For any question or issue with the software `open an issue <https://github.com/g
 Release
 -------
 
-* Tag the new version with git
-* Make sure ``hatch`` detects the right version with ``hatch version``
-* Build with ``hatch build``
-* Upload to pypi with ``hatch publish``
-* Upload to Github with ``git push --tags``
+1. Review ``CHANGES.rst`` and move the entries you want to ship out of the
+   ``Unreleased`` section into a dated ``<version> (<YYYY-MM-DD>)`` heading.
+   Commit the changelog update (and any other release-related changes).
+2. Ensure the working tree is clean and up to date with ``git status`` and
+   ``git pull``.
+3. Create or refresh a local environment using ``uv``::
+
+       uv venv .venv
+       uv pip install --python .venv/bin/python pip hatch
+
+   Activate it for the remaining steps with ``source .venv/bin/activate``.
+4. Run the test suite (at least ``pytest``) to verify the release build.
+5. Create the annotated release tag, e.g. ``git tag -a 3.4.3 -m "Release 3.4.3"``.
+6. Confirm Hatch picks up the tagged version::
+
+       hatch version
+
+   The output should match the tag (no ``.dev`` suffix).
+7. Build the distribution artifacts::
+
+       hatch build
+
+8. Publish to PyPI using your API token. Hatch reads credentials from
+   ``~/.pypirc`` (username ``__token__``). Alternatively export
+   ``HATCH_INDEX_USER=__token__`` and ``HATCH_INDEX_AUTH=<pypi-token>`` before
+   running::
+
+       hatch publish --no-prompt
+
+9. Push the tag (and any commits) to GitHub::
+
+       git push --tags
+
+10. Draft the GitHub release notes referencing the matching ``CHANGES.rst``
+    entry and announce the release as needed.
 
 .. |CI Tests| image:: https://github.com/galsci/pysm/actions/workflows/ci_tests.yml/badge.svg
    :target: https://github.com/galsci/pysm/actions/workflows/ci_tests.yml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@
 import os
 import sys
 import datetime
+import warnings
 from importlib import import_module
 
 try:
@@ -50,6 +51,11 @@ config = SphinxConfig(
     globalns=globals(),
     config_overrides={"version": pysm3.__version__},
 )
+
+nbsphinx_widgets_path = ""
+
+# Suppress noisy SyntaxWarning messages from legacy notebooks
+warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence")
 
 
 # -- General configuration ----------------------------------------------------
@@ -206,6 +212,6 @@ linkcheck_anchors = False
 #     nitpick_ignore.append((dtype, six.u(target)))
 
 extensions += ["nbsphinx", "sphinx_math_dollar", "sphinx.ext.mathjax"]
-exclude_patterns += ["_build", "**.ipynb_checkpoints", "**utils*"]
+exclude_patterns += ["_build", "**.ipynb_checkpoints"]
 nbsphinx_kernel_name = "python3"
 nbsphinx_execute = "never"

--- a/docs/customize_components.ipynb
+++ b/docs/customize_components.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "There are 3 straightforward ways to customize PySM models.\n",
     "\n",
-    "First we can still keep the same algorithms used to generate the components and just provide different templates/paramers, we can achieve this either [using configuration files](#use_a_configuration_file) or, for more flexibility, [work directly with the component Python object](#work_with_python_class).\n",
+    "First we can still keep the same algorithms used to generate the components and just provide different templates/parameters. We can achieve this either using configuration files or, for more flexibility, by working directly with the component Python object.\n",
     "\n",
-    "Instead if we need to implement different algorithms, we need to [implement a subclass of pysm3.Model](#implement_a_subclass_of_pysm.Model)"
+    "If we need to implement different algorithms, we can implement a subclass of ``pysm3.Model``.\n"
    ]
   },
   {
@@ -62,9 +62,10 @@
     }
    ],
    "source": [
-    "%%file mydust.cfg\n",
+    "from pathlib import Path\n",
     "\n",
-    "[dustfixedspec]\n",
+    "Path(\"mydust.cfg\").write_text(\n",
+    "    \"\"\"[dustfixedspec]\n",
     "class = \"ModifiedBlackBody\"\n",
     "map_I = \"pysm_2/dust_t_new.fits\"\n",
     "map_Q = \"pysm_2/dust_q_new.fits\"\n",
@@ -76,7 +77,9 @@
     "map_mbb_temperature = \"pysm_2/dust_temp.fits\"\n",
     "unit_mbb_temperature = \"K\"\n",
     "freq_ref_I = \"545 GHz\"\n",
-    "freq_ref_P = \"353 GHz\""
+    "freq_ref_P = \"353 GHz\"\n",
+    "\"\"\"\n",
+    ")\n"
    ]
   },
   {
@@ -318,7 +321,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Implement a subclass of pysm3.Model"
+    "<a id=\"implement-a-subclass-of-pysm3-model\"></a>\n",
+    "## Implement a subclass of pysm3.Model\n"
    ]
   },
   {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -189,6 +189,50 @@ All the tutorials are Jupyter Notebooks and can be accessed `from the repository
   customize_components
   mpi
 
+Template preprocessing notebooks
+================================
+
+The following notebooks document the data-processing workflow used to build the
+high-resolution templates shipped with PySM.
+
+.. toctree::
+  :maxdepth: 1
+
+  Commander dust preprocessing <preprocess-templates/reproduce_pysm2_dust_pol>
+  WMAP synchrotron preprocessing <preprocess-templates/reproduce_pysm2_sync_pol>
+  Small-scale dust generation overview <preprocess-templates/small_scale_dust_pysm3>
+  Generate dust small-scale artifacts <preprocess-templates/small_scale_dust_pysm3_generate_artifacts>
+  Generate PySM3 dust templates <preprocess-templates/small_scale_dust_pysm3_generate_templates>
+  Synchrotron beta small-scale modelling <preprocess-templates/synchrotron_beta>
+  Synchrotron curvature modelling <preprocess-templates/synchrotron_curvature>
+  Log-pol-tens formalism notebook <preprocess-templates/synchrotron_template_logpoltens>
+  WebSky bright source catalog workflow <preprocess-templates/websky_sources_high_flux_catalog>
+  Verify dust templates <preprocess-templates/verify_templates/verify_templates_dust>
+  Verify synchrotron templates <preprocess-templates/verify_templates/verify_templates_synch>
+
+Catalog generation notebooks
+============================
+
+.. toctree::
+  :maxdepth: 1
+
+  Create WebSky background catalog with Dask <preprocess-templates/catalog/background_create_websky_catalog_dask>
+  Assemble WebSky background catalog with Dask <preprocess-templates/catalog/background_dask_assemble_catalog>
+  Compare catalog and original WebSky sources <preprocess-templates/catalog/compare_catalog_to_original_websky>
+  Inspect WebSky high-flux catalog output <preprocess-templates/catalog/websky_sources_high_flux_catalog_out_1mJy>
+
+Template utility notebooks
+==========================
+
+.. toctree::
+  :maxdepth: 1
+
+  GNILC dust spectral index and temperature maps <preprocess-templates/gnilc_dust_spectralindex_Tdust>
+  Generate GNILC spectral index and temperature maps <preprocess-templates/utils_gnilc_generate_map_spectralindex_Td>
+  Generate synchrotron amplitude map <preprocess-templates/utils_synch_generate_map>
+  Compute synchrotron curvature harmonic coefficients <preprocess-templates/utils_synch_generate_map_curvature>
+  Generate synchrotron spectral index map <preprocess-templates/utils_synch_generate_map_spectralindex>
+
 Contributing
 ============
 
@@ -196,6 +240,15 @@ Contributing
   :maxdepth: 2
 
   contributing
+
+Supplementary material
+======================
+
+.. toctree::
+  :maxdepth: 1
+
+  websky
+  pysm_methods_author_contributions
 
 Reference/API
 =============

--- a/docs/preprocess-templates/catalog/background_create_websky_catalog_dask.ipynb
+++ b/docs/preprocess-templates/catalog/background_create_websky_catalog_dask.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create WebSky background catalog with Dask\n"
+   ],
+   "id": "dfbf38472bca"
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "0ed31a46-d481-4958-af82-3889e2f6b80a",

--- a/docs/preprocess-templates/catalog/background_dask_assemble_catalog.ipynb
+++ b/docs/preprocess-templates/catalog/background_dask_assemble_catalog.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Assemble WebSky background catalog with Dask\n"
+   ],
+   "id": "01fb53b775b0"
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "0ed31a46-d481-4958-af82-3889e2f6b80a",

--- a/docs/preprocess-templates/catalog/websky_sources_high_flux_catalog_out_1mJy.ipynb
+++ b/docs/preprocess-templates/catalog/websky_sources_high_flux_catalog_out_1mJy.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inspect WebSky high-flux catalog output\n"
+   ],
+   "id": "93de97223d71"
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "0",

--- a/docs/preprocess-templates/gnilc_dust_spectralindex_Tdust.ipynb
+++ b/docs/preprocess-templates/gnilc_dust_spectralindex_Tdust.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GNILC dust spectral index and temperature maps\n"
+   ],
+   "id": "16bcca02bfcb"
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "815c1aee",
@@ -331,8 +339,8 @@
     "tags": []
    },
    "source": [
-    "# Setting the inputs \n",
-    "## Dust maps \n",
+    "## Setting the inputs \n",
+    "### Dust maps \n",
     "- We use the  2015 GNILC intensity map from the 2nd planck release, as it encodes less contamination from CIB with 21.8' resolution https://www.dropbox.com/s/hicocet83z31ob3/COM_CompMap_Dust-GNILC-F353_2048_21p8acm.fits?dl=0\n",
     "\n",
     "- for Q and U we adopt maps from the 3rd Planck release as they were optimized for polarization studies with 80' reso.  \n",
@@ -517,7 +525,7 @@
     "tags": []
    },
    "source": [
-    "## Amplitude modulation"
+    "### Amplitude modulation"
    ]
   },
   {
@@ -564,7 +572,7 @@
     "tags": []
    },
    "source": [
-    "## Injecting small scales to Spectral parameters "
+    "### Injecting small scales to Spectral parameters "
    ]
   },
   {
@@ -884,7 +892,7 @@
     "tags": []
    },
    "source": [
-    "### Small scales"
+    "#### Small scales"
    ]
   },
   {
@@ -1017,7 +1025,7 @@
     "tags": []
    },
    "source": [
-    "### Large scales"
+    "#### Large scales"
    ]
   },
   {
@@ -1122,7 +1130,7 @@
     "tags": []
    },
    "source": [
-    "### Final map"
+    "#### Final map"
    ]
   },
   {
@@ -1459,7 +1467,7 @@
     "tags": []
    },
    "source": [
-    "## Galactic plane fix\n",
+    "### Galactic plane fix\n",
     "\n",
     "As in the templates, we replace the inner part of the galactic plane with the actual input data"
    ]

--- a/docs/preprocess-templates/reproduce_pysm2_dust_pol.ipynb
+++ b/docs/preprocess-templates/reproduce_pysm2_dust_pol.ipynb
@@ -5,7 +5,8 @@
    "metadata": {},
    "source": [
     "# Reproduce PySM 2 small scales for dust polarization\n"
-   ]
+   ],
+   "id": "a160bbbf7c6c"
   },
   {
    "cell_type": "markdown",
@@ -13,7 +14,8 @@
    "source": [
     "The purpose of this notebook is to reproduce the analysis described in the [PySM 2 paper](https://arxiv.org/pdf/1608.02841.pdf) to prepare the input templates used in the Galactic dust and synchrotron models.\n",
     "In summary we take input template maps from Planck or other sources, smooth them to remove noise and add small scale gaussian fluctuations."
-   ]
+   ],
+   "id": "84d66a8653e7"
   },
   {
    "cell_type": "code",
@@ -23,7 +25,8 @@
    "source": [
     "import os\n",
     "os.environ[\"OMP_NUM_THREADS\"] = \"64\""
-   ]
+   ],
+   "id": "0bd688d78d97"
   },
   {
    "cell_type": "code",
@@ -37,7 +40,8 @@
     "import numpy as np\n",
     "from astropy.io import fits\n",
     "%matplotlib inline"
-   ]
+   ],
+   "id": "50fcae43cbaa"
   },
   {
    "cell_type": "code",
@@ -46,7 +50,8 @@
    "outputs": [],
    "source": [
     "hp.disable_warnings()"
-   ]
+   ],
+   "id": "8e7ab06e96c7"
   },
   {
    "cell_type": "code",
@@ -55,7 +60,8 @@
    "outputs": [],
    "source": [
     "plt.style.use(\"seaborn-talk\")"
-   ]
+   ],
+   "id": "0fb3550639e4"
   },
   {
    "cell_type": "code",
@@ -65,7 +71,8 @@
    "source": [
     "import pysm3 as pysm\n",
     "import pysm3.units as u"
-   ]
+   ],
+   "id": "a3c2e8068737"
   },
   {
    "cell_type": "code",
@@ -75,7 +82,8 @@
    "source": [
     "nside = 1024\n",
     "lmax = 3 * nside - 1"
-   ]
+   ],
+   "id": "520c924ce6fd"
   },
   {
    "cell_type": "markdown",
@@ -84,14 +92,16 @@
     "## Masks\n",
     "\n",
     "Using the Planck 80% Galactic mask (the WMAP ones is for synchrotron)."
-   ]
+   ],
+   "id": "94568ce3fd78"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The Planck foreground mask is also available with apodization of 2 or 5 degrees, here is the one with no apodization"
-   ]
+   ],
+   "id": "25473c5d4b63"
   },
   {
    "cell_type": "code",
@@ -100,7 +110,8 @@
    "outputs": [],
    "source": [
     "planck_map_filename = \"HFI_Mask_GalPlane-apo0_2048_R2.00.fits\""
-   ]
+   ],
+   "id": "22506cb0e359"
   },
   {
    "cell_type": "code",
@@ -110,7 +121,8 @@
    "source": [
     "if not os.path.exists(planck_map_filename):\n",
     "    !wget https://irsa.ipac.caltech.edu/data/Planck/release_2/ancillary-data/masks/$planck_map_filename"
-   ]
+   ],
+   "id": "a4a76195082f"
   },
   {
    "cell_type": "code",
@@ -183,7 +195,8 @@
    ],
    "source": [
     "fits.open(planck_map_filename)[1].header"
-   ]
+   ],
+   "id": "9f1d2cbf571e"
   },
   {
    "cell_type": "code",
@@ -192,7 +205,8 @@
    "outputs": [],
    "source": [
     "planck_gal80_mask = hp.read_map(planck_map_filename, (\"GAL080\",))"
-   ]
+   ],
+   "id": "23c6c95dd0ea"
   },
   {
    "cell_type": "code",
@@ -214,14 +228,16 @@
    ],
    "source": [
     "hp.mollview(planck_gal80_mask, title=\"Planck galactic mask 80% no apodization\")"
-   ]
+   ],
+   "id": "8f3f0e95034e"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "We need to downgrade the Planck mask from 2048 to 1024, so we average 4 pixels, we consider a pixel un-masked if 3 of the 4 pixels are unmasked."
-   ]
+   ],
+   "id": "979ffca5a7a0"
   },
   {
    "cell_type": "code",
@@ -230,14 +246,16 @@
    "outputs": [],
    "source": [
     "# total_mask = np.logical_and(hp.ud_grade(wmap_mask, nside), hp.ud_grade(planck_gal80_mask, nside)>=.75)"
-   ]
+   ],
+   "id": "ba9d4e640a41"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "We can check how many pixels have the value of 0,0.25,0.5,0.75,1"
-   ]
+   ],
+   "id": "c3c5c603ab42"
   },
   {
    "cell_type": "code",
@@ -257,7 +275,8 @@
    ],
    "source": [
     "np.bincount((4*hp.ud_grade(planck_gal80_mask, nside)).astype(np.int64))"
-   ]
+   ],
+   "id": "1b1516de4b99"
   },
   {
    "cell_type": "code",
@@ -266,7 +285,8 @@
    "outputs": [],
    "source": [
     "total_mask = hp.ud_grade(planck_gal80_mask, nside)>=.75"
-   ]
+   ],
+   "id": "95601fa2ed74"
   },
   {
    "cell_type": "code",
@@ -275,7 +295,8 @@
    "outputs": [],
    "source": [
     "hp.write_map(\"total_mask.fits\", total_mask.astype(np.int), overwrite=True)"
-   ]
+   ],
+   "id": "2abb5c164638"
   },
   {
    "cell_type": "code",
@@ -297,7 +318,8 @@
    ],
    "source": [
     "hp.mollview(total_mask, title=\"Total mask\")"
-   ]
+   ],
+   "id": "1a1c70068185"
   },
   {
    "cell_type": "markdown",
@@ -310,7 +332,8 @@
     "https://irsa.ipac.caltech.edu/data/Planck/release_2/all-sky-maps/previews/COM_CompMap_DustPol-commander_1024_R2.00/index.html\n",
     "\n",
     "We are trying to reproduce the PySM 2 results so we are using the Commander release 2 results. Later on we can switch to the last Planck release."
-   ]
+   ],
+   "id": "db4c22f4f385"
   },
   {
    "cell_type": "code",
@@ -319,7 +342,8 @@
    "outputs": [],
    "source": [
     "commander_dust_map_filename = \"COM_CompMap_DustPol-commander_1024_R2.00.fits\""
-   ]
+   ],
+   "id": "973c10eb24b2"
   },
   {
    "cell_type": "code",
@@ -329,7 +353,8 @@
    "source": [
     "if not os.path.exists(commander_dust_map_filename):\n",
     "    !wget https://irsa.ipac.caltech.edu/data/Planck/release_2/all-sky-maps/maps/component-maps/foregrounds/$commander_dust_map_filename"
-   ]
+   ],
+   "id": "118f67f02fed"
   },
   {
    "cell_type": "markdown",
@@ -337,7 +362,8 @@
    "source": [
     "The input map has no temperature, we repeat the Q component for T as well,\n",
     "this doesn't impact the polarization spectra:"
-   ]
+   ],
+   "id": "8e32e57ecc9e"
   },
   {
    "cell_type": "code",
@@ -346,7 +372,8 @@
    "outputs": [],
    "source": [
     "m_planck,h = hp.read_map(\"./COM_CompMap_DustPol-commander_1024_R2.00.fits\", (0,0,1), h=True)"
-   ]
+   ],
+   "id": "c85b421f7cad"
   },
   {
    "cell_type": "code",
@@ -465,7 +492,8 @@
    ],
    "source": [
     "h"
-   ]
+   ],
+   "id": "cfc76d406d3b"
   },
   {
    "cell_type": "code",
@@ -500,7 +528,8 @@
    "source": [
     "for i_pol, pol in [(1, \"Q\"), (2, \"U\")]:\n",
     "    hp.mollview(m_planck[i_pol], title=\"Planck-Commander dust polarization \" + pol, unit=\"uK_RJ\", min=-300, max=300)"
-   ]
+   ],
+   "id": "b66ce810fa24"
   },
   {
    "cell_type": "code",
@@ -510,7 +539,8 @@
    "source": [
     "# A T map set to 0 is not supported by PolSpice\n",
     "m_planck[0] = 1"
-   ]
+   ],
+   "id": "95c47d482126"
   },
   {
    "cell_type": "markdown",
@@ -518,14 +548,16 @@
    "source": [
     "## Extend spectrum to small scales\n",
     "\n"
-   ]
+   ],
+   "id": "a1fe03199615"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Angular power spectrum with NaMaster"
-   ]
+   ],
+   "id": "eed22c7889af"
   },
   {
    "cell_type": "code",
@@ -534,7 +566,8 @@
    "outputs": [],
    "source": [
     "import pymaster as nmt"
-   ]
+   ],
+   "id": "583b491b6f6f"
   },
   {
    "cell_type": "code",
@@ -556,7 +589,8 @@
    ],
    "source": [
     "hp.mollview(m_planck[1])"
-   ]
+   ],
+   "id": "a218a970e99c"
   },
   {
    "cell_type": "code",
@@ -574,19 +608,22 @@
     "    cl[1, 2:] = cl_22[0]\n",
     "    cl[2, 2:] = cl_22[3]\n",
     "    return ell_arr, cl"
-   ]
+   ],
+   "id": "54bd1577d3ee"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [],
+   "id": "773bef5be48c"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [],
+   "id": "a9fe2f4fb5f8"
   },
   {
    "cell_type": "code",
@@ -595,14 +632,16 @@
    "outputs": [],
    "source": [
     "ell_arr, spice_cl = run_namaster(m_planck[1:], total_mask)"
-   ]
+   ],
+   "id": "37ac63ef8789"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [],
+   "id": "1ade56f65128"
   },
   {
    "cell_type": "code",
@@ -641,7 +680,8 @@
     "plt.grid()\n",
     "plt.xlim([0, 400])\n",
     "plt.show()"
-   ]
+   ],
+   "id": "4853d452c837"
   },
   {
    "cell_type": "code",
@@ -651,7 +691,8 @@
    "source": [
     "ell = np.arange(spice_cl.shape[1])\n",
     "cl_norm = ell*(ell+1)/np.pi/2"
-   ]
+   ],
+   "id": "26f45ea55ccf"
   },
   {
    "cell_type": "markdown",
@@ -662,7 +703,8 @@
     "\n",
     "The power spectrum features a power law behaviour $\\ell < 200$ (linear in `loglog` axes), then white noise\n",
     "starts picking up until $\\ell=1000$ and then we see the smoothing applied to the maps (10 arcminutes)."
-   ]
+   ],
+   "id": "6aee8bdcb800"
   },
   {
    "cell_type": "code",
@@ -672,7 +714,8 @@
    "source": [
     "ell_fit_low = 50\n",
     "ell_fit_high = 200"
-   ]
+   ],
+   "id": "15ce72beb8f8"
   },
   {
    "cell_type": "code",
@@ -709,7 +752,8 @@
     "plt.legend()\n",
     "plt.xlim([0, 400])\n",
     "plt.grid();"
-   ]
+   ],
+   "id": "33fb13bd87ed"
   },
   {
    "cell_type": "markdown",
@@ -725,7 +769,8 @@
     "average where we see the spectrum flattening out.\n",
     "There are many parameters here we can tweak, the target here is just to check we can recover something\n",
     "similar to the PySM 2 paper."
-   ]
+   ],
+   "id": "532b536f420a"
   },
   {
    "cell_type": "code",
@@ -734,7 +779,8 @@
    "outputs": [],
    "source": [
     "smoothing_beam = hp.gauss_beam(fwhm=(10 * u.arcmin).to_value(u.radian), lmax=lmax)"
-   ]
+   ],
+   "id": "33c0b3501d0c"
   },
   {
    "cell_type": "code",
@@ -743,7 +789,8 @@
    "outputs": [],
    "source": [
     "noise_bias = (spice_cl[1:, 750:850] / smoothing_beam[750:850]**2).mean(axis=1)"
-   ]
+   ],
+   "id": "234eb897a61c"
   },
   {
    "cell_type": "code",
@@ -752,7 +799,8 @@
    "outputs": [],
    "source": [
     "noise_bias = {\"EE\":noise_bias[0], \"BB\":noise_bias[1]}"
-   ]
+   ],
+   "id": "83bd65c75c69"
   },
   {
    "cell_type": "code",
@@ -785,7 +833,8 @@
     "    plt.axhline(noise_bias[pol], color=color, label=f\"noise bias {pol}\")\n",
     "#plt.xlim([0, 400])\n",
     "plt.grid();"
-   ]
+   ],
+   "id": "d4f0bb4d74b2"
   },
   {
    "cell_type": "code",
@@ -805,7 +854,8 @@
    ],
    "source": [
     "noise_bias"
-   ]
+   ],
+   "id": "4830e877abba"
   },
   {
    "cell_type": "code",
@@ -834,7 +884,8 @@
     "    plt.axhline(noise_bias[pol], color=color, label=f\"noise bias {pol}\")\n",
     "plt.legend()\n",
     "plt.grid();"
-   ]
+   ],
+   "id": "6cbb6e606d8d"
   },
   {
    "cell_type": "code",
@@ -865,7 +916,8 @@
     "plt.xlim([4e2, 2e3])\n",
     "plt.ylim([8e-5, 5e-4])\n",
     "plt.grid();"
-   ]
+   ],
+   "id": "e4c844d58d59"
   },
   {
    "cell_type": "markdown",
@@ -874,7 +926,8 @@
     "### Fit for the slope at high ell\n",
     "\n",
     "We assume the same model from the paper and fit for an amplitude and a power law exponent (slope in log-log)"
-   ]
+   ],
+   "id": "b730e0e1da90"
   },
   {
    "cell_type": "code",
@@ -883,7 +936,8 @@
    "outputs": [],
    "source": [
     "from scipy.optimize import curve_fit"
-   ]
+   ],
+   "id": "34aebf9538f5"
   },
   {
    "cell_type": "code",
@@ -893,7 +947,8 @@
    "source": [
     "def model(ell, A, gamma):\n",
     "    return A * ell ** gamma"
-   ]
+   ],
+   "id": "1611ac371d52"
   },
   {
    "cell_type": "code",
@@ -902,7 +957,8 @@
    "outputs": [],
    "source": [
     "xdata = np.arange(ell_fit_low, ell_fit_high)"
-   ]
+   ],
+   "id": "05d367c6c247"
   },
   {
    "cell_type": "code",
@@ -965,7 +1021,8 @@
     "    plt.title(f\"{pol} power spectrum for dust\")\n",
     "    #plt.xlim(0, 400)\n",
     "    #plt.ylim(1, 30);"
-   ]
+   ],
+   "id": "2f1185b24678"
   },
   {
    "cell_type": "code",
@@ -986,7 +1043,8 @@
    ],
    "source": [
     "A_fit, A_fit_std"
-   ]
+   ],
+   "id": "93400a2000e1"
   },
   {
    "cell_type": "code",
@@ -1007,14 +1065,16 @@
    ],
    "source": [
     "gamma_fit, gamma_fit_std"
-   ]
+   ],
+   "id": "4814b1770388"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The paper mentions a $\\gamma^{EE,dust} = -.31$ and a $\\gamma^{BB,dust} = -.15$.\n"
-   ]
+   ],
+   "id": "a41228809b4b"
   },
   {
    "cell_type": "markdown",
@@ -1023,14 +1083,16 @@
     "### Window function\n",
     "\n",
     "The window function is used to smooth the input templates to remove the high $\\ell$ noise and its inverse is used for the added small scales."
-   ]
+   ],
+   "id": "7e2c99cb4f55"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "$\\ell_*^{dust}$"
-   ]
+   ],
+   "id": "a1e5aaf6a6cd"
   },
   {
    "cell_type": "code",
@@ -1039,7 +1101,8 @@
    "outputs": [],
    "source": [
     "ell_star = 69"
-   ]
+   ],
+   "id": "022df17249dd"
   },
   {
    "cell_type": "code",
@@ -1048,7 +1111,8 @@
    "outputs": [],
    "source": [
     "theta_fwhm_deg = 180/ell_star"
-   ]
+   ],
+   "id": "67a6ddc16a21"
   },
   {
    "cell_type": "code",
@@ -1068,7 +1132,8 @@
    ],
    "source": [
     "theta_fwhm_deg"
-   ]
+   ],
+   "id": "c6b17fb8744f"
   },
   {
    "cell_type": "code",
@@ -1077,7 +1142,8 @@
    "outputs": [],
    "source": [
     "theta_fwhm = np.radians(theta_fwhm_deg)"
-   ]
+   ],
+   "id": "8d4aff21438a"
   },
   {
    "cell_type": "code",
@@ -1086,7 +1152,8 @@
    "outputs": [],
    "source": [
     "w_ell = hp.gauss_beam(fwhm=theta_fwhm, lmax=lmax)"
-   ]
+   ],
+   "id": "d5970b9fbbae"
   },
   {
    "cell_type": "code",
@@ -1106,7 +1173,8 @@
    ],
    "source": [
     "w_ell.shape"
-   ]
+   ],
+   "id": "c894a27c808d"
   },
   {
    "cell_type": "markdown",
@@ -1116,7 +1184,8 @@
     "\n",
     "This process doesn't have a large impact on the output spectra, the idea is that in each $N_{side}=2$ pixel we want to scale the gaussian fluctuations so that they are consistent with the power at low ell.\n",
     "So we will have higher gaussian fluctuations on the galaxy where there is stronger dust emission."
-   ]
+   ],
+   "id": "e1de5a96eeb7"
   },
   {
    "cell_type": "code",
@@ -1125,7 +1194,8 @@
    "outputs": [],
    "source": [
     "patch_indices = hp.ud_grade(np.arange(hp.nside2npix(2)), nside)"
-   ]
+   ],
+   "id": "ea81c0eb4042"
   },
   {
    "cell_type": "code",
@@ -1147,7 +1217,8 @@
    ],
    "source": [
     "hp.mollview(patch_indices)"
-   ]
+   ],
+   "id": "d15cd14f1cf6"
   },
   {
    "cell_type": "code",
@@ -1156,7 +1227,8 @@
    "outputs": [],
    "source": [
     "zeros = np.zeros(len(ell), dtype=np.double)"
-   ]
+   ],
+   "id": "375a7dd50a5e"
   },
   {
    "cell_type": "code",
@@ -1165,7 +1237,8 @@
    "outputs": [],
    "source": [
     "inv_w_ell = 1 - w_ell**2"
-   ]
+   ],
+   "id": "37c141014cd5"
   },
   {
    "cell_type": "code",
@@ -1175,7 +1248,8 @@
    "source": [
     "nside_patches = 2\n",
     "n_patches = hp.nside2npix(nside_patches)"
-   ]
+   ],
+   "id": "269c98e57cfa"
   },
   {
    "cell_type": "code",
@@ -1207,7 +1281,8 @@
    ],
    "source": [
     "plt.loglog(inv_w_ell)"
-   ]
+   ],
+   "id": "1394d70de278"
   },
   {
    "cell_type": "code",
@@ -1229,7 +1304,8 @@
    ],
    "source": [
     "hp.mollview(m_planck[1])"
-   ]
+   ],
+   "id": "978321f3f5f7"
   },
   {
    "cell_type": "code",
@@ -1252,7 +1328,8 @@
     "    zeros,\n",
     "    A_fit[\"EE\"] * ell**gamma_fit[\"EE\"] * inv_w_ell / cl_norm,A_fit[\"BB\"] * ell**gamma_fit[\"BB\"] * inv_w_ell / cl_norm,\n",
     "    zeros, zeros, zeros], nside, new=True)"
-   ]
+   ],
+   "id": "9546e19e27db"
   },
   {
    "cell_type": "code",
@@ -1274,7 +1351,8 @@
    ],
    "source": [
     "hp.mollview(m_sigma_G[0])"
-   ]
+   ],
+   "id": "7afecbb470b8"
   },
   {
    "cell_type": "code",
@@ -1283,7 +1361,8 @@
    "outputs": [],
    "source": [
     "N = {i_pol:np.zeros(n_patches, dtype=np.double) for i_pol in [1,2]}"
-   ]
+   ],
+   "id": "15f76b038034"
   },
   {
    "cell_type": "code",
@@ -1292,7 +1371,8 @@
    "outputs": [],
    "source": [
     "m_planck[0] = 0"
-   ]
+   ],
+   "id": "aa32691af200"
   },
   {
    "cell_type": "code",
@@ -1302,7 +1382,8 @@
    "source": [
     "m_planck_smoothed = hp.alm2map(hp.smoothalm(hp.map2alm(m_planck, use_pixel_weights=True), fwhm=theta_fwhm),\n",
     "                               nside=nside)"
-   ]
+   ],
+   "id": "5cce3a84f65b"
   },
   {
    "cell_type": "code",
@@ -1324,7 +1405,8 @@
    ],
    "source": [
     "hp.mollview(m_planck_smoothed[1])"
-   ]
+   ],
+   "id": "805fb07d144f"
   },
   {
    "cell_type": "code",
@@ -1394,7 +1476,8 @@
     "    cl_patch = hp.anafast(m_patch, lmax=2*ell_star, use_pixel_weights=True)\n",
     "    for pol,i_pol in [(\"EE\", 1),(\"BB\",2)]:\n",
     "        N[i_pol][i_patch] = np.sqrt(cl_patch[i_pol][ell_star] / n_patches / (A_fit[pol] * ell_star ** gamma_fit[pol]))"
-   ]
+   ],
+   "id": "f8dba40e1f81"
   },
   {
    "cell_type": "code",
@@ -1427,7 +1510,8 @@
    "source": [
     "plt.loglog(cl_patch[1])\n",
     "plt.axvline(ell_star)"
-   ]
+   ],
+   "id": "63420dfac1aa"
   },
   {
    "cell_type": "code",
@@ -1449,7 +1533,8 @@
    ],
    "source": [
     "hp.mollview(N[1])"
-   ]
+   ],
+   "id": "29548d370e18"
   },
   {
    "cell_type": "code",
@@ -1458,7 +1543,8 @@
    "outputs": [],
    "source": [
     "m_zeros = np.zeros(hp.nside2npix(nside), dtype=np.double)"
-   ]
+   ],
+   "id": "5213fd048a2f"
   },
   {
    "cell_type": "code",
@@ -1467,7 +1553,8 @@
    "outputs": [],
    "source": [
     "N_smoothed = hp.smoothing([m_zeros, hp.ud_grade(N[1], nside), hp.ud_grade(N[2], nside)], fwhm=np.radians(10))"
-   ]
+   ],
+   "id": "23036fc39732"
   },
   {
    "cell_type": "code",
@@ -1476,7 +1563,8 @@
    "outputs": [],
    "source": [
     "N_smoothed[1] /= N_smoothed[1].mean()"
-   ]
+   ],
+   "id": "67b34c7a121c"
   },
   {
    "cell_type": "code",
@@ -1485,7 +1573,8 @@
    "outputs": [],
    "source": [
     "N_smoothed[2] /= N_smoothed[2].mean() "
-   ]
+   ],
+   "id": "99c4b283afcd"
   },
   {
    "cell_type": "code",
@@ -1507,14 +1596,16 @@
    ],
    "source": [
     "hp.mollview(N_smoothed[1], cmap=\"jet\")"
-   ]
+   ],
+   "id": "b5ac1da7fc69"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "This also is quite different from Figure 9 in the paper, but it is not the main issue, possibly I need to use PolSpice instead of anafast?"
-   ]
+   ],
+   "id": "7eab73337534"
   },
   {
    "cell_type": "code",
@@ -1536,7 +1627,8 @@
    ],
    "source": [
     "hp.mollview(N_smoothed[1], min=0, max=6, cmap=\"jet\")"
-   ]
+   ],
+   "id": "c612b222ab8e"
   },
   {
    "cell_type": "markdown",
@@ -1545,7 +1637,8 @@
     "## Run PolSpice on the total map and just on the small scales\n",
     "\n",
     "Always using the same Gal80 Planck mask"
-   ]
+   ],
+   "id": "154128c150cf"
   },
   {
    "cell_type": "code",
@@ -1554,7 +1647,8 @@
    "outputs": [],
    "source": [
     "m_total = m_planck_smoothed + m_sigma_G * N_smoothed"
-   ]
+   ],
+   "id": "d26880d31a1b"
   },
   {
    "cell_type": "code",
@@ -1563,7 +1657,8 @@
    "outputs": [],
    "source": [
     "m_total[0] = 1"
-   ]
+   ],
+   "id": "7a0d2bde0fae"
   },
   {
    "cell_type": "code",
@@ -1572,7 +1667,8 @@
    "outputs": [],
    "source": [
     "_, cl_total = run_namaster(m_total[1:], total_mask)"
-   ]
+   ],
+   "id": "7979d539aa13"
   },
   {
    "cell_type": "code",
@@ -1581,7 +1677,8 @@
    "outputs": [],
    "source": [
     "m_sigma_G[0]=1"
-   ]
+   ],
+   "id": "50d4ca32379d"
   },
   {
    "cell_type": "code",
@@ -1590,7 +1687,8 @@
    "outputs": [],
    "source": [
     "N_smoothed[0]=1"
-   ]
+   ],
+   "id": "828fb3c0dbc6"
   },
   {
    "cell_type": "code",
@@ -1599,14 +1697,16 @@
    "outputs": [],
    "source": [
     "_, cl_sigma_G_uniform = run_namaster(m_sigma_G[1:], total_mask)"
-   ]
+   ],
+   "id": "4128855f5a7e"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Download PySM 2 templates"
-   ]
+   ],
+   "id": "ed8a1c8cb47e"
   },
   {
    "cell_type": "code",
@@ -1618,7 +1718,8 @@
     "    filename = f\"dust_{comp}_new.fits\"\n",
     "    if not os.path.exists(filename):\n",
     "        !wget https://portal.nersc.gov/project/cmb/pysm-data/pysm_2/$filename"
-   ]
+   ],
+   "id": "ff67ee62498c"
   },
   {
    "cell_type": "code",
@@ -1638,7 +1739,8 @@
    ],
    "source": [
     "total_mask.shape"
-   ]
+   ],
+   "id": "950c36089a7f"
   },
   {
    "cell_type": "code",
@@ -1647,7 +1749,8 @@
    "outputs": [],
    "source": [
     "total_mask_512 = hp.ud_grade(total_mask, 512)>=.75"
-   ]
+   ],
+   "id": "4234fbeaf168"
   },
   {
    "cell_type": "code",
@@ -1656,7 +1759,8 @@
    "outputs": [],
    "source": [
     "m_pysm2 = np.array([hp.read_map(f\"dust_{comp}_new.fits\") for comp in \"tqu\"])"
-   ]
+   ],
+   "id": "0b8de4cf950a"
   },
   {
    "cell_type": "code",
@@ -1665,7 +1769,8 @@
    "outputs": [],
    "source": [
     "ell_arr_512, cl_pysm2 = run_namaster(m_pysm2[1:], total_mask_512)"
-   ]
+   ],
+   "id": "a16d7313041e"
   },
   {
    "cell_type": "markdown",
@@ -1677,7 +1782,8 @@
     "this has the same impact we can see on the plot in the paper copied at the bottom\n",
     "of the Notebook, the red line which is the fitted spectrum is less steep than\n",
     "the actual small scale realization."
-   ]
+   ],
+   "id": "26813f974ee9"
   },
   {
    "cell_type": "code",
@@ -1737,14 +1843,16 @@
     "    plt.ylabel(\"$\\ell(\\ell+1)C_\\ell/2\\pi$\")\n",
     "    plt.xlabel(\"$\\ell$\")\n",
     "    plt.grid();"
-   ]
+   ],
+   "id": "e240c1cf8db9"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Compare PySM 2, the input and the output"
-   ]
+   ],
+   "id": "4bbdc098bd4e"
   },
   {
    "cell_type": "code",
@@ -1804,14 +1912,16 @@
     "    plt.ylabel(\"$\\ell(\\ell+1)C_\\ell/2\\pi$\")\n",
     "    plt.xlabel(\"$\\ell$\")\n",
     "    plt.grid();"
-   ]
+   ],
+   "id": "04a1c1e2ef38"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "We can also compare with the dust BB plot (Figure 7) from the PySM 2 paper below"
-   ]
+   ],
+   "id": "176e0ff1b8cb"
   },
   {
    "cell_type": "code",
@@ -1833,14 +1943,16 @@
    "source": [
     "from IPython.display import Image\n",
     "Image(\"BB_dust_PySM_2_paper.png\")"
-   ]
+   ],
+   "id": "8da187c56625"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# "
-   ]
+   ],
+   "id": "fbc3e5b96971"
   }
  ],
  "metadata": {

--- a/docs/preprocess-templates/reproduce_pysm2_sync_pol.ipynb
+++ b/docs/preprocess-templates/reproduce_pysm2_sync_pol.ipynb
@@ -4,8 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Reproduce PySM 2 synchrotron polarization templates"
-   ]
+    "# Reproduce PySM 2 synchrotron polarization templates\n"
+   ],
+   "id": "e9dab4ef9e0e"
   },
   {
    "cell_type": "markdown",
@@ -13,7 +14,8 @@
    "source": [
     "The purpose of this notebook is to reproduce the analysis described in the [PySM 2 paper](https://arxiv.org/pdf/1608.02841.pdf) to prepare the input templates used in the Galactic dust and synchrotron models.\n",
     "In summary we take input template maps from Planck or other sources, smooth them to remove noise and add small scale gaussian fluctuations."
-   ]
+   ],
+   "id": "b551c5ba7c9e"
   },
   {
    "cell_type": "code",
@@ -27,7 +29,8 @@
     "import numpy as np\n",
     "from astropy.io import fits\n",
     "%matplotlib inline"
-   ]
+   ],
+   "id": "64b56fc15bbf"
   },
   {
    "cell_type": "code",
@@ -37,7 +40,8 @@
    "source": [
     "import os\n",
     "os.environ[\"OMP_NUM_THREADS\"] = \"32\""
-   ]
+   ],
+   "id": "0d6b36d4bee9"
   },
   {
    "cell_type": "code",
@@ -46,7 +50,8 @@
    "outputs": [],
    "source": [
     "hp.disable_warnings()"
-   ]
+   ],
+   "id": "f038c3f3188e"
   },
   {
    "cell_type": "code",
@@ -55,7 +60,8 @@
    "outputs": [],
    "source": [
     "plt.style.use(\"seaborn-talk\")"
-   ]
+   ],
+   "id": "cf5c404d3794"
   },
   {
    "cell_type": "code",
@@ -65,7 +71,8 @@
    "source": [
     "import pysm3 as pysm\n",
     "import pysm3.units as u"
-   ]
+   ],
+   "id": "7d5ee5527639"
   },
   {
    "cell_type": "code",
@@ -75,16 +82,18 @@
    "source": [
     "nside = 512\n",
     "lmax = 3 * nside - 1"
-   ]
+   ],
+   "id": "438babe376ee"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Masks\n",
+    "### Masks\n",
     "\n",
     "For synchrotron we use the WMAP polarization analysis mask"
-   ]
+   ],
+   "id": "52c48d336a40"
   },
   {
    "cell_type": "code",
@@ -93,7 +102,8 @@
    "outputs": [],
    "source": [
     "wmap_mask_filename = \"wmap_polarization_analysis_mask_r9_9yr_v5.fits\""
-   ]
+   ],
+   "id": "2141669ff547"
   },
   {
    "cell_type": "code",
@@ -103,7 +113,8 @@
    "source": [
     "if not os.path.exists(wmap_mask_filename):\n",
     "    !wget https://lambda.gsfc.nasa.gov/data/map/dr5/ancillary/masks/$wmap_mask_filename"
-   ]
+   ],
+   "id": "c361445679b6"
   },
   {
    "cell_type": "code",
@@ -142,7 +153,8 @@
    ],
    "source": [
     "fits.open(wmap_mask_filename)[1].header"
-   ]
+   ],
+   "id": "a88b971986f4"
   },
   {
    "cell_type": "code",
@@ -151,7 +163,8 @@
    "outputs": [],
    "source": [
     "wmap_mask = hp.read_map(wmap_mask_filename,0)"
-   ]
+   ],
+   "id": "45953f692ed4"
   },
   {
    "cell_type": "code",
@@ -173,7 +186,8 @@
    ],
    "source": [
     "hp.mollview(wmap_mask, title=\"WMAP DR5 polarization analysis mask\")"
-   ]
+   ],
+   "id": "566c35c0bc1f"
   },
   {
    "cell_type": "code",
@@ -182,7 +196,8 @@
    "outputs": [],
    "source": [
     "total_mask = hp.ud_grade(wmap_mask, nside)"
-   ]
+   ],
+   "id": "b62b7bb49c8f"
   },
   {
    "cell_type": "code",
@@ -191,7 +206,8 @@
    "outputs": [],
    "source": [
     "f_sky = total_mask.sum()/len(total_mask)"
-   ]
+   ],
+   "id": "008776fa7f6b"
   },
   {
    "cell_type": "code",
@@ -211,7 +227,8 @@
    ],
    "source": [
     "f_sky"
-   ]
+   ],
+   "id": "02c69bf79874"
   },
   {
    "cell_type": "code",
@@ -233,28 +250,31 @@
    ],
    "source": [
     "hp.mollview(total_mask, title=\"Total mask\")"
-   ]
+   ],
+   "id": "e77f4e2796e6"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [],
+   "id": "56fca5118c37"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Synchrotron model\n",
+    "### Synchrotron model\n",
     "\n",
-    "### Spectral index\n",
+    "#### Spectral index\n",
     "\n",
     "As in the nominal Planck Sky Model v1.7.8 simulations,\n",
     "we use the spectral index map from ‘Model 4’ of [MivilleDeschenes et al. (2008)](https://arxiv.org/abs/0802.3345), calculated from a combination of\n",
     "Haslam and WMAP 23 GHz polarization data using a model\n",
     "of the Galactic magnetic field."
-   ]
+   ],
+   "id": "a002e7bcbf12"
   },
   {
    "cell_type": "code",
@@ -263,7 +283,8 @@
    "outputs": [],
    "source": [
     "pysm2_beta = hp.read_map(\"https://portal.nersc.gov/project/cmb/pysm-data/pysm_2/synch_beta.fits\")"
-   ]
+   ],
+   "id": "435147e7d2e3"
   },
   {
    "cell_type": "code",
@@ -285,7 +306,8 @@
    ],
    "source": [
     "hp.mollview(pysm2_beta, title=\"Synchrotron spectral index from MivilleDeschenes 2008\")"
-   ]
+   ],
+   "id": "0ed5a71f6582"
   },
   {
    "cell_type": "code",
@@ -305,18 +327,20 @@
    ],
    "source": [
     "hp.npix2nside(len(pysm2_beta))"
-   ]
+   ],
+   "id": "e7d7b08632f8"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Synchrotron templates\n",
+    "### Synchrotron templates\n",
     "\n",
     "The nominal PySM model assumes that the synchrotron intensity is a scaling of the degree-scale-smoothed 408 MHz\n",
     "Haslam map (Haslam et al. 1981; Haslam et al. 1982), reprocessed by [Remazeilles et al. (2014)](https://arxiv.org/abs/1411.3628v1). It models the polarization as a scaling of the WMAP 9-year 23 GHz Q and U\n",
     "maps (Bennett et al. 2013), smoothed to three degrees.\n"
-   ]
+   ],
+   "id": "1d0dd154a858"
   },
   {
    "cell_type": "code",
@@ -325,7 +349,8 @@
    "outputs": [],
    "source": [
     "wmap_23GHz_map_filename = \"wmap_band_iqumap_r9_9yr_K_v5.fits\""
-   ]
+   ],
+   "id": "076064a1ff2a"
   },
   {
    "cell_type": "code",
@@ -335,7 +360,8 @@
    "source": [
     "if not os.path.exists(wmap_23GHz_map_filename):\n",
     "    !wget https://lambda.gsfc.nasa.gov/data/map/dr5/skymaps/9yr/raw/$wmap_23GHz_map_filename"
-   ]
+   ],
+   "id": "c0b3461ea13e"
   },
   {
    "cell_type": "code",
@@ -344,7 +370,8 @@
    "outputs": [],
    "source": [
     "wmap_23GHz_map,wmap_23GHz_header = hp.read_map(wmap_23GHz_map_filename, (0,1,2), h=True)"
-   ]
+   ],
+   "id": "d5154a200f6f"
   },
   {
    "cell_type": "code",
@@ -390,7 +417,8 @@
    ],
    "source": [
     "wmap_23GHz_header"
-   ]
+   ],
+   "id": "8b6ed10cfb94"
   },
   {
    "cell_type": "code",
@@ -399,7 +427,8 @@
    "outputs": [],
    "source": [
     "wmap_23GHz_map <<= u.mK_CMB"
-   ]
+   ],
+   "id": "67214180dae0"
   },
   {
    "cell_type": "code",
@@ -429,7 +458,8 @@
    ],
    "source": [
     "wmap_23GHz_map "
-   ]
+   ],
+   "id": "6a277eec89e3"
   },
   {
    "cell_type": "code",
@@ -464,7 +494,8 @@
    "source": [
     "for i_pol, pol in [(1, \"Q\"), (2, \"U\")]:\n",
     "    hp.mollview(wmap_23GHz_map[i_pol].to_value(\"uK_CMB\"), title=\"WMAP polarization \" + pol, unit=\"uK_CMB\", min=-300, max=300)"
-   ]
+   ],
+   "id": "43f898155fc4"
   },
   {
    "cell_type": "code",
@@ -473,7 +504,8 @@
    "outputs": [],
    "source": [
     "target_unit = u.uK_RJ"
-   ]
+   ],
+   "id": "39ec8f1b3f7b"
   },
   {
    "cell_type": "code",
@@ -482,7 +514,8 @@
    "outputs": [],
    "source": [
     "K_CMB_2_K_RJ = (1 * wmap_23GHz_map.unit).to_value(target_unit , equivalencies=u.cmb_equivalencies(23*u.GHz))"
-   ]
+   ],
+   "id": "3e8dcb263546"
   },
   {
    "cell_type": "code",
@@ -502,14 +535,16 @@
    ],
    "source": [
     "K_CMB_2_K_RJ"
-   ]
+   ],
+   "id": "7dcbaf61bdce"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "This is the effective frequency of the WMAP K band using the effective frequency calculator from <https://lambda.gsfc.nasa.gov/product/map/current/effective_freq.cfm> using a spectral index of -3:"
-   ]
+   ],
+   "id": "c71327d98be1"
   },
   {
    "cell_type": "code",
@@ -532,7 +567,8 @@
    ],
    "source": [
     "(1 * u.K_CMB).to(u.K_RJ , equivalencies=u.cmb_equivalencies(2.24357e+01*u.GHz))"
-   ]
+   ],
+   "id": "dbccf5e1637a"
   },
   {
    "cell_type": "code",
@@ -541,7 +577,8 @@
    "outputs": [],
    "source": [
     "smoothing_fwhm = 3 * u.deg"
-   ]
+   ],
+   "id": "c0d64a89db8f"
   },
   {
    "cell_type": "code",
@@ -550,7 +587,8 @@
    "outputs": [],
    "source": [
     "ell_star_synch = 36"
-   ]
+   ],
+   "id": "f861e08a8c8a"
   },
   {
    "cell_type": "code",
@@ -559,7 +597,8 @@
    "outputs": [],
    "source": [
     "#synch_amplitude = hp.smoothing(wmap_23GHz_map.value, fwhm=(180 * u.deg / ell_star_synch).to_value(u.rad)) * wmap_23GHz_map.unit"
-   ]
+   ],
+   "id": "567866d93db6"
   },
   {
    "cell_type": "code",
@@ -568,7 +607,8 @@
    "outputs": [],
    "source": [
     "synch_amplitude = wmap_23GHz_map"
-   ]
+   ],
+   "id": "3221efdf7e36"
   },
   {
    "cell_type": "code",
@@ -577,7 +617,8 @@
    "outputs": [],
    "source": [
     "wmap_23GHz_frequency = 2.24357e+01*u.GHz"
-   ]
+   ],
+   "id": "3820b687ca73"
   },
   {
    "cell_type": "code",
@@ -586,20 +627,22 @@
    "outputs": [],
    "source": [
     "synch_amplitude = synch_amplitude.to(target_unit, equivalencies=u.cmb_equivalencies(wmap_23GHz_frequency))[1:]"
-   ]
+   ],
+   "id": "649fa8425dd3"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Angular power spectrum\n",
+    "### Angular power spectrum\n",
     "\n",
     "We use namaster to estimate the power spectrum of the masked map,\n",
     "compared to `anafast`, namaster properly deconvolves the mask to remove the\n",
     "correlations between different $C_\\ell$ caused by the mask.\n",
     "\n",
     "We don't need to deconvolve the beam, we won't be using the values at high $\\ell$ anyway."
-   ]
+   ],
+   "id": "73ca5be8338a"
   },
   {
    "cell_type": "code",
@@ -608,7 +651,8 @@
    "outputs": [],
    "source": [
     "from reprocess_utils import run_namaster"
-   ]
+   ],
+   "id": "65ce03f0e285"
   },
   {
    "cell_type": "code",
@@ -617,7 +661,8 @@
    "outputs": [],
    "source": [
     "ell, cl = run_namaster(synch_amplitude, total_mask)"
-   ]
+   ],
+   "id": "76c87abd3f75"
   },
   {
    "cell_type": "code",
@@ -628,7 +673,8 @@
     "import pymaster as nmt\n",
     "mask = total_mask\n",
     "m = synch_amplitude"
-   ]
+   ],
+   "id": "7ce7bb3c2a32"
   },
   {
    "cell_type": "code",
@@ -646,7 +692,8 @@
     "    cl = np.zeros((3, len(ell_arr)), dtype=np.double) \n",
     "    cl[1, 2:] = cl_22[0] \n",
     "    cl[2, 2:] = cl_22[3] \n"
-   ]
+   ],
+   "id": "0cf5d377b7be"
   },
   {
    "cell_type": "code",
@@ -678,7 +725,8 @@
    ],
    "source": [
     "plt.loglog(cl_22[2])"
-   ]
+   ],
+   "id": "5475827a0bad"
   },
   {
    "cell_type": "code",
@@ -698,7 +746,8 @@
    ],
    "source": [
     "cl.shape"
-   ]
+   ],
+   "id": "8b5fbcc9268d"
   },
   {
    "cell_type": "code",
@@ -707,7 +756,8 @@
    "outputs": [],
    "source": [
     "cl_norm = ell*(ell+1)/np.pi/2"
-   ]
+   ],
+   "id": "20a06da38947"
   },
   {
    "cell_type": "markdown",
@@ -718,7 +768,8 @@
     "\n",
     "The power spectrum features a power law behaviour $\\ell < 200$ (linear in `loglog` axes), then white noise\n",
     "starts picking up until $\\ell=1000$ and then we see the smoothing applied to the maps (10 arcminutes)."
-   ]
+   ],
+   "id": "2741508ac0f0"
   },
   {
    "cell_type": "code",
@@ -728,14 +779,16 @@
    "source": [
     "ell_fit_low = 2\n",
     "ell_fit_high = 80"
-   ]
+   ],
+   "id": "8ae6a809e99a"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Fit noise bias"
-   ]
+    "#### Fit noise bias"
+   ],
+   "id": "797617953126"
   },
   {
    "cell_type": "code",
@@ -747,7 +800,8 @@
     "noise_bias_ell_high = 1000\n",
     "noise_bias = (cl[1:, noise_bias_ell_low:noise_bias_ell_high]).mean(axis=1)\n",
     "noise_bias = {\"EE\":noise_bias[0], \"BB\":noise_bias[1]}"
-   ]
+   ],
+   "id": "045420d35e22"
   },
   {
    "cell_type": "code",
@@ -756,7 +810,8 @@
    "outputs": [],
    "source": [
     "# noise_bias[\"BB\"] = noise_bias[\"EE\"]"
-   ]
+   ],
+   "id": "98955ab7ba9d"
   },
   {
    "cell_type": "code",
@@ -776,7 +831,8 @@
    ],
    "source": [
     "noise_bias"
-   ]
+   ],
+   "id": "470e99051102"
   },
   {
    "cell_type": "code",
@@ -819,7 +875,8 @@
     "#plt.xlim(2,200)\n",
     "plt.ylim(0,.1)\n",
     "plt.grid();"
-   ]
+   ],
+   "id": "b7c6355e2568"
   },
   {
    "cell_type": "code",
@@ -839,7 +896,8 @@
    ],
    "source": [
     "(cl_norm * cl[2])[2]"
-   ]
+   ],
+   "id": "ebc61f040525"
   },
   {
    "cell_type": "code",
@@ -848,7 +906,8 @@
    "outputs": [],
    "source": [
     "cosmic_variance = np.sqrt(2/((2*ell+1)*f_sky))*cl"
-   ]
+   ],
+   "id": "2c533b012d24"
   },
   {
    "cell_type": "code",
@@ -873,7 +932,8 @@
    ],
    "source": [
     "cosmic_variance"
-   ]
+   ],
+   "id": "95cdfb18b706"
   },
   {
    "cell_type": "code",
@@ -911,7 +971,8 @@
     "plt.xlim(2,200)\n",
     "plt.ylim(8,2e2)\n",
     "plt.grid();"
-   ]
+   ],
+   "id": "16a896697b83"
   },
   {
    "cell_type": "code",
@@ -942,14 +1003,16 @@
     "\n",
     "#plt.xlim(2,200)\n",
     "plt.grid();"
-   ]
+   ],
+   "id": "474864ef44ad"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Fit slope at high ell"
-   ]
+    "#### Fit slope at high ell"
+   ],
+   "id": "0ed1037e24e6"
   },
   {
    "cell_type": "code",
@@ -958,7 +1021,8 @@
    "outputs": [],
    "source": [
     "from scipy.optimize import curve_fit"
-   ]
+   ],
+   "id": "1fdc69fef6c4"
   },
   {
    "cell_type": "code",
@@ -968,7 +1032,8 @@
    "source": [
     "def model(ell, A, gamma):\n",
     "    return A * ell ** gamma# + N* ell*(ell+1)/np.pi/2"
-   ]
+   ],
+   "id": "f9eccf05d1b9"
   },
   {
    "cell_type": "code",
@@ -977,7 +1042,8 @@
    "outputs": [],
    "source": [
     "xdata = np.arange(ell_fit_low, ell_fit_high)"
-   ]
+   ],
+   "id": "62f5e8257268"
   },
   {
    "cell_type": "code",
@@ -998,7 +1064,8 @@
    ],
    "source": [
     "cl_norm"
-   ]
+   ],
+   "id": "47bed2880938"
   },
   {
    "cell_type": "code",
@@ -1060,7 +1127,8 @@
     "    plt.xlim(2,200)\n",
     "    plt.ylim(1,200)\n",
     "    #plt.ylim(1, 30);"
-   ]
+   ],
+   "id": "b88438adec3d"
   },
   {
    "cell_type": "code",
@@ -1082,14 +1150,16 @@
    "source": [
     "from IPython.display import Image\n",
     "Image(\"BB_synch_inputs_PySM_2_paper.png\")"
-   ]
+   ],
+   "id": "8f692b567b37"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The paper mentions a $\\gamma^{EE,synch} = -.66$ and a $\\gamma^{BB,synch} = -.62$.\n"
-   ]
+   ],
+   "id": "7244873d5205"
   },
   {
    "cell_type": "code",
@@ -1109,27 +1179,30 @@
    ],
    "source": [
     "gamma_fit"
-   ]
+   ],
+   "id": "7599a03d8bf3"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Window function\n",
+    "#### Window function\n",
     "\n",
     "The window function is used to smooth the input templates to remove the high $\\ell$ noise and its inverse is used for the added small scales.\n",
     "\n",
     "In the paper it mentions that the large scales map is smoothed with a beam of $180/\\ell_*^{synch}$ degrees, but looking at the PySM 2 templates, it looks like the spectrum is still flat after the supposed cutoff of the beam, see the end of this notebook.\n",
     "\n",
     "So I tested using the same $\\ell_*$ used for dust, i.e. 2.6 deg smoothingi instead of 5, but still the spectrum in PySM 2 seems flatter at intermediate $\\ell$."
-   ]
+   ],
+   "id": "a692162ee6f9"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "$\\ell_*^{synch}$"
-   ]
+   ],
+   "id": "569ede6aa00f"
   },
   {
    "cell_type": "code",
@@ -1139,7 +1212,8 @@
    "source": [
     "ell_star = 36\n",
     "ell_star = 69"
-   ]
+   ],
+   "id": "ad3212e3b34a"
   },
   {
    "cell_type": "code",
@@ -1148,7 +1222,8 @@
    "outputs": [],
    "source": [
     "theta_fwhm_deg = 180/ell_star"
-   ]
+   ],
+   "id": "e97850828b94"
   },
   {
    "cell_type": "code",
@@ -1168,7 +1243,8 @@
    ],
    "source": [
     "theta_fwhm_deg"
-   ]
+   ],
+   "id": "799081b08cc2"
   },
   {
    "cell_type": "code",
@@ -1177,7 +1253,8 @@
    "outputs": [],
    "source": [
     "theta_fwhm = np.radians(theta_fwhm_deg)"
-   ]
+   ],
+   "id": "25129b7f744c"
   },
   {
    "cell_type": "code",
@@ -1186,7 +1263,8 @@
    "outputs": [],
    "source": [
     "w_ell = hp.gauss_beam(fwhm=theta_fwhm, lmax=lmax)"
-   ]
+   ],
+   "id": "f6c96675da29"
   },
   {
    "cell_type": "code",
@@ -1206,17 +1284,19 @@
    ],
    "source": [
     "w_ell.shape"
-   ]
+   ],
+   "id": "130d1fc8c505"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Process patches\n",
+    "### Process patches\n",
     "\n",
     "This process doesn't have a large impact on the output spectra, the idea is that in each $N_{side}=2$ pixel we want to scale the gaussian fluctuations so that they are consistent with the power at low ell.\n",
     "So we will have higher gaussian fluctuations on the galaxy where there is stronger dust emission."
-   ]
+   ],
+   "id": "abb133de2114"
   },
   {
    "cell_type": "code",
@@ -1225,7 +1305,8 @@
    "outputs": [],
    "source": [
     "patch_indices = hp.ud_grade(np.arange(hp.nside2npix(2)), nside)"
-   ]
+   ],
+   "id": "e666a5a07b43"
   },
   {
    "cell_type": "code",
@@ -1234,7 +1315,8 @@
    "outputs": [],
    "source": [
     "zeros = np.zeros(len(ell), dtype=np.double)"
-   ]
+   ],
+   "id": "b1222b03a5a3"
   },
   {
    "cell_type": "code",
@@ -1243,7 +1325,8 @@
    "outputs": [],
    "source": [
     "inv_w_ell = 1 - w_ell**2"
-   ]
+   ],
+   "id": "dbc3c51ead37"
   },
   {
    "cell_type": "code",
@@ -1253,7 +1336,8 @@
    "source": [
     "nside_patches = 2\n",
     "n_patches = hp.nside2npix(nside_patches)"
-   ]
+   ],
+   "id": "6d95df9fe261"
   },
   {
    "cell_type": "code",
@@ -1276,7 +1360,8 @@
     "    zeros,\n",
     "    A_fit[\"EE\"] * ell**gamma_fit[\"EE\"] * inv_w_ell / cl_norm,A_fit[\"BB\"] * ell**gamma_fit[\"BB\"] * inv_w_ell / cl_norm,\n",
     "    zeros, zeros, zeros], nside, new=True)"
-   ]
+   ],
+   "id": "ab829ff5dde9"
   },
   {
    "cell_type": "code",
@@ -1285,7 +1370,8 @@
    "outputs": [],
    "source": [
     "N = {i_pol:np.zeros(n_patches, dtype=np.double) for i_pol in [1,2]}"
-   ]
+   ],
+   "id": "1f9aa5c73012"
   },
   {
    "cell_type": "code",
@@ -1294,7 +1380,8 @@
    "outputs": [],
    "source": [
     "synch_amplitude = wmap_23GHz_map.to(u.uK_RJ, equivalencies=u.cmb_equivalencies(wmap_23GHz_frequency))"
-   ]
+   ],
+   "id": "af9796de2f52"
   },
   {
    "cell_type": "code",
@@ -1303,7 +1390,8 @@
    "outputs": [],
    "source": [
     "synch_amplitude[0]=0"
-   ]
+   ],
+   "id": "a4768b27e073"
   },
   {
    "cell_type": "code",
@@ -1313,7 +1401,8 @@
    "source": [
     "m_planck_smoothed = hp.alm2map(hp.smoothalm(hp.map2alm(synch_amplitude.value, use_pixel_weights=True), fwhm=theta_fwhm),\n",
     "                               nside=nside)"
-   ]
+   ],
+   "id": "d2aa167536a6"
   },
   {
    "cell_type": "code",
@@ -1383,7 +1472,8 @@
     "    cl_patch = hp.anafast(m_patch, lmax=2*ell_star, use_pixel_weights=True)\n",
     "    for pol,i_pol in [(\"EE\", 1),(\"BB\",2)]:\n",
     "        N[i_pol][i_patch] = np.sqrt(cl_patch[i_pol][ell_star] / n_patches / (A_fit[pol] * ell_star ** gamma_fit[pol]))"
-   ]
+   ],
+   "id": "93b1fb38c430"
   },
   {
    "cell_type": "code",
@@ -1416,7 +1506,8 @@
    "source": [
     "plt.loglog(cl_patch[1])\n",
     "plt.axvline(ell_star)"
-   ]
+   ],
+   "id": "fd4f9873b49b"
   },
   {
    "cell_type": "code",
@@ -1438,7 +1529,8 @@
    ],
    "source": [
     "hp.mollview(N[1])"
-   ]
+   ],
+   "id": "d14021471e7c"
   },
   {
    "cell_type": "code",
@@ -1447,7 +1539,8 @@
    "outputs": [],
    "source": [
     "m_zeros = np.zeros(hp.nside2npix(nside), dtype=np.double)"
-   ]
+   ],
+   "id": "ec978442f1ed"
   },
   {
    "cell_type": "code",
@@ -1456,7 +1549,8 @@
    "outputs": [],
    "source": [
     "N_smoothed = hp.smoothing([m_zeros, hp.ud_grade(N[1], nside), hp.ud_grade(N[2], nside)], fwhm=np.radians(10))"
-   ]
+   ],
+   "id": "935a9b92cb19"
   },
   {
    "cell_type": "code",
@@ -1465,7 +1559,8 @@
    "outputs": [],
    "source": [
     "N_smoothed[1] /= N_smoothed[1].mean()"
-   ]
+   ],
+   "id": "5f51ccf9ab59"
   },
   {
    "cell_type": "code",
@@ -1474,7 +1569,8 @@
    "outputs": [],
    "source": [
     "N_smoothed[2] /= N_smoothed[2].mean() "
-   ]
+   ],
+   "id": "478ce498d93c"
   },
   {
    "cell_type": "code",
@@ -1496,14 +1592,16 @@
    ],
    "source": [
     "hp.mollview(N_smoothed[1], cmap=\"jet\")"
-   ]
+   ],
+   "id": "e8651a7783a9"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "This also is quite different from Figure 9 in the paper, but it is not the main issue, possibly I need to use PolSpice instead of anafast?"
-   ]
+   ],
+   "id": "36c2be98422d"
   },
   {
    "cell_type": "code",
@@ -1525,16 +1623,18 @@
    ],
    "source": [
     "hp.mollview(N_smoothed[1], min=0, max=6, cmap=\"jet\")"
-   ]
+   ],
+   "id": "3fdeebd54228"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run PolSpice on the total map and just on the small scales\n",
+    "### Run PolSpice on the total map and just on the small scales\n",
     "\n",
     "Always using the same Gal80 Planck mask"
-   ]
+   ],
+   "id": "ab38818eb0ac"
   },
   {
    "cell_type": "code",
@@ -1543,7 +1643,8 @@
    "outputs": [],
    "source": [
     "m_total = m_planck_smoothed + m_sigma_G * N_smoothed"
-   ]
+   ],
+   "id": "bae43ca66a4d"
   },
   {
    "cell_type": "code",
@@ -1552,7 +1653,8 @@
    "outputs": [],
    "source": [
     "m_total[0] = 1"
-   ]
+   ],
+   "id": "a3abfc95a281"
   },
   {
    "cell_type": "code",
@@ -1561,7 +1663,8 @@
    "outputs": [],
    "source": [
     "_, cl_total = run_namaster(m_total[1:], total_mask)"
-   ]
+   ],
+   "id": "385b82c8e8ea"
   },
   {
    "cell_type": "code",
@@ -1570,7 +1673,8 @@
    "outputs": [],
    "source": [
     "m_sigma_G[0]=0"
-   ]
+   ],
+   "id": "498d1e881014"
   },
   {
    "cell_type": "code",
@@ -1579,14 +1683,16 @@
    "outputs": [],
    "source": [
     "_, cl_sigma_G_uniform = run_namaster(m_sigma_G[1:], total_mask)"
-   ]
+   ],
+   "id": "373bf380ef7c"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Download PySM 2 templates"
-   ]
+    "### Download PySM 2 templates"
+   ],
+   "id": "86b286fc632c"
   },
   {
    "cell_type": "code",
@@ -1598,7 +1704,8 @@
     "    filename = f\"synch_{comp}_new.fits\"\n",
     "    if not os.path.exists(filename):\n",
     "        !wget https://portal.nersc.gov/project/cmb/pysm-data/pysm_2/$filename"
-   ]
+   ],
+   "id": "dfb1df3b9c3e"
   },
   {
    "cell_type": "code",
@@ -1607,7 +1714,8 @@
    "outputs": [],
    "source": [
     "m_pysm2 = np.array([hp.read_map(f\"synch_{comp}_new.fits\") for comp in \"qu\"])"
-   ]
+   ],
+   "id": "9702d8995ee7"
   },
   {
    "cell_type": "code",
@@ -1616,7 +1724,8 @@
    "outputs": [],
    "source": [
     "total_mask_512 = hp.ud_grade(total_mask, 512)>=.75"
-   ]
+   ],
+   "id": "ecf1b390f07c"
   },
   {
    "cell_type": "code",
@@ -1625,14 +1734,16 @@
    "outputs": [],
    "source": [
     "ell_arr_512, cl_pysm2 = run_namaster(m_pysm2, total_mask_512)"
-   ]
+   ],
+   "id": "a3f3deeda53b"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Compare PySM 2, the input and the output"
-   ]
+    "### Compare PySM 2, the input and the output"
+   ],
+   "id": "30af8cb13fb5"
   },
   {
    "cell_type": "code",
@@ -1692,14 +1803,16 @@
     "    plt.xlabel(\"$\\ell$\")\n",
     "    plt.ylabel(\"$\\ell(\\ell+1)/2\\pi~C_\\ell~[\\mu K_{RJ}^2]$\")\n",
     "    plt.grid();"
-   ]
+   ],
+   "id": "cd46bf107bac"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "We can also compare with the synchrotron BB plot (Figure 7) from the PySM 2 paper below"
-   ]
+   ],
+   "id": "e615f42418d9"
   },
   {
    "cell_type": "code",
@@ -1721,13 +1834,14 @@
    "source": [
     "from IPython.display import Image\n",
     "Image(\"BB_synch_PySM_2_paper.png\")"
-   ]
+   ],
+   "id": "7532556c136d"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Conclusions\n",
+    "### Conclusions\n",
     "\n",
     "There are 2 issue with trying to reproduce the PySM 2 processing of the synchrotron templates for polarization:\n",
     "\n",
@@ -1735,7 +1849,8 @@
     "* the figure in cell 93, just above here, shows higher power in the $\\ell$ range 60-100 in EE, which should be over the beam cutoff so should just be dominated by the small scales realization\n",
     "\n",
     "If anyone is interested in investigating this, the source notebook doesn't require any external data and is available [on Github](https://github.com/galsci/pysm/tree/main/docs/template_preprocessing), please [open an issue](https://github.com/galsci/pysm/issues) to report your findings."
-   ]
+   ],
+   "id": "c342c56ce0f0"
   }
  ],
  "metadata": {

--- a/docs/preprocess-templates/small_scale_dust_pysm3_generate_templates.ipynb
+++ b/docs/preprocess-templates/small_scale_dust_pysm3_generate_templates.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate PySM 3 dust templates\n"
+   ],
+   "id": "2ed068588048"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -9,7 +17,8 @@
     "import numpy as np\n",
     "import healpy as hp\n",
     "from pathlib import Path"
-   ]
+   ],
+   "id": "48cfaae0621d"
   },
   {
    "cell_type": "code",
@@ -18,7 +27,8 @@
    "outputs": [],
    "source": [
     "output_dir = Path(\"production-data\") / \"dust_gnilc\""
-   ]
+   ],
+   "id": "47e6bd8f0b59"
   },
   {
    "cell_type": "code",
@@ -27,7 +37,8 @@
    "outputs": [],
    "source": [
     "datadir = output_dir / \"raw\""
-   ]
+   ],
+   "id": "7b9eb1d70fb1"
   },
   {
    "cell_type": "code",
@@ -40,7 +51,8 @@
    "outputs": [],
    "source": [
     "output_nside = 2048"
-   ]
+   ],
+   "id": "dccbdbc48b71"
   },
   {
    "cell_type": "code",
@@ -49,14 +61,16 @@
    "outputs": [],
    "source": [
     "output_lmax = int(min(2.5 * output_nside, 8192 * 2))"
-   ]
+   ],
+   "id": "950b1909e84c"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Large scales"
-   ]
+    "### Large scales"
+   ],
+   "id": "53af8b33c36a"
   },
   {
    "cell_type": "code",
@@ -69,7 +83,8 @@
     "    / \"gnilc_dust_largescale_template_logpoltens_alm_nside2048_lmax1024_complex64.fits.gz\",\n",
     "    hdu=(1, 2, 3),\n",
     ")"
-   ]
+   ],
+   "id": "4e48f1c05433"
   },
   {
    "cell_type": "code",
@@ -80,7 +95,8 @@
     "map_log_pol_tens_large_scale = hp.alm2map(\n",
     "    alm_log_pol_tens_large_scale.astype(np.complex128), nside=output_nside\n",
     ")"
-   ]
+   ],
+   "id": "98eb63a9250e"
   },
   {
    "cell_type": "code",
@@ -89,14 +105,16 @@
    "outputs": [],
    "source": [
     "map_log_pol_tens_large_scale"
-   ]
+   ],
+   "id": "7908e4405531"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Small scales modulation"
-   ]
+    "### Small scales modulation"
+   ],
+   "id": "8ce22a074df8"
   },
   {
    "cell_type": "code",
@@ -110,14 +128,16 @@
     "    )\n",
     "    for k in [\"temperature\", \"polarization\"]\n",
     "}"
-   ]
+   ],
+   "id": "80e047e38757"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Small scales"
-   ]
+    "### Small scales"
+   ],
+   "id": "c15b62f4b866"
   },
   {
    "cell_type": "code",
@@ -128,7 +148,8 @@
     "cl_small_scale = hp.read_cl(\n",
     "    datadir / \"gnilc_dust_small_scales_logpoltens_cl_lmax16384.fits.gz\"\n",
     ")"
-   ]
+   ],
+   "id": "65b6f864c42e"
   },
   {
    "cell_type": "code",
@@ -145,7 +166,8 @@
     "    lmax=synalm_lmax,\n",
     "    new=True,\n",
     ")"
-   ]
+   ],
+   "id": "86d65d0ddc44"
   },
   {
    "cell_type": "code",
@@ -160,7 +182,8 @@
     "map_log_pol_tens_small_scale = hp.alm2map(\n",
     "    alm_log_pol_tens_small_scale, nside=output_nside\n",
     ")"
-   ]
+   ],
+   "id": "b2c5877b295c"
   },
   {
    "cell_type": "code",
@@ -169,7 +192,8 @@
    "outputs": [],
    "source": [
     "map_log_pol_tens_small_scale"
-   ]
+   ],
+   "id": "b3330f0697f1"
   },
   {
    "cell_type": "code",
@@ -184,7 +208,8 @@
     "    modulate_alm[\"polarization\"], output_nside\n",
     ")\n",
     "assert np.isnan(map_log_pol_tens_small_scale).sum() == 0"
-   ]
+   ],
+   "id": "2cc72d118afb"
   },
   {
    "cell_type": "code",
@@ -193,18 +218,20 @@
    "outputs": [],
    "source": [
     "map_log_pol_tens_small_scale"
-   ]
+   ],
+   "id": "f75e306938de"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Combine scales\n",
+    "### Combine scales\n",
     "\n",
     "* Combine small and large scale maps\n",
     "* Transform from logpoltens to IQU\n",
     "* Write output map"
-   ]
+   ],
+   "id": "af33e7eec6de"
   },
   {
    "cell_type": "code",
@@ -214,7 +241,8 @@
    "source": [
     "map_log_pol_tens = map_log_pol_tens_large_scale\n",
     "map_log_pol_tens += map_log_pol_tens_small_scale"
-   ]
+   ],
+   "id": "ce59ea49c4a8"
   },
   {
    "cell_type": "code",
@@ -223,7 +251,8 @@
    "outputs": [],
    "source": [
     "del map_log_pol_tens_small_scale"
-   ]
+   ],
+   "id": "66a6eab0e160"
   },
   {
    "cell_type": "code",
@@ -232,7 +261,8 @@
    "outputs": [],
    "source": [
     "from pysm3.utils import log_pol_tens_to_map"
-   ]
+   ],
+   "id": "212e42f5fa92"
   },
   {
    "cell_type": "code",
@@ -241,7 +271,8 @@
    "outputs": [],
    "source": [
     "output_map = log_pol_tens_to_map(map_log_pol_tens)"
-   ]
+   ],
+   "id": "16bfc43c96f1"
   },
   {
    "cell_type": "code",
@@ -250,7 +281,8 @@
    "outputs": [],
    "source": [
     "output_map"
-   ]
+   ],
+   "id": "5c9942bb12d8"
   },
   {
    "cell_type": "code",
@@ -259,14 +291,16 @@
    "outputs": [],
    "source": [
     "del map_log_pol_tens"
-   ]
+   ],
+   "id": "1bae29d4ad6f"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Galactic plane fix"
-   ]
+    "### Galactic plane fix"
+   ],
+   "id": "58d9dd0b5071"
   },
   {
    "cell_type": "code",
@@ -275,7 +309,8 @@
    "outputs": [],
    "source": [
     "galplane_fix = hp.read_map(datadir / \"gnilc_dust_galplane.fits.gz\", (0, 1, 2, 3))"
-   ]
+   ],
+   "id": "5b5d84f4aa7c"
   },
   {
    "cell_type": "code",
@@ -285,7 +320,8 @@
    "source": [
     "output_map *= hp.ud_grade(galplane_fix[3], output_nside)\n",
     "output_map += hp.ud_grade(galplane_fix[:3] * (1 - galplane_fix[3]), output_nside)"
-   ]
+   ],
+   "id": "477f09d0394f"
   },
   {
    "cell_type": "code",
@@ -294,21 +330,24 @@
    "outputs": [],
    "source": [
     "output_map"
-   ]
+   ],
+   "id": "80e079069071"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Color correction"
-   ]
+    "### Color correction"
+   ],
+   "id": "e4f3f733db2e"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Planck 353 GHz color correction https://github.com/galsci/pysm/issues/99"
-   ]
+   ],
+   "id": "787262707ace"
   },
   {
    "cell_type": "code",
@@ -317,7 +356,8 @@
    "outputs": [],
    "source": [
     "output_map *= 0.911"
-   ]
+   ],
+   "id": "139dffbc9734"
   },
   {
    "cell_type": "code",
@@ -326,7 +366,8 @@
    "outputs": [],
    "source": [
     "output_map"
-   ]
+   ],
+   "id": "0f64832c7fa0"
   },
   {
    "cell_type": "code",
@@ -342,7 +383,8 @@
     "    column_units = \"uK_RJ\",\n",
     "    extra_header = [(\"lmax\", output_lmax), (\"ref_freq\", \"353 GHz\")]\n",
     ")"
-   ]
+   ],
+   "id": "c9b2f02097aa"
   }
  ],
  "metadata": {

--- a/docs/preprocess-templates/synchrotron_beta.ipynb
+++ b/docs/preprocess-templates/synchrotron_beta.ipynb
@@ -5,7 +5,7 @@
    "id": "a086c311-a05a-4077-85d2-717bcbbc215a",
    "metadata": {},
    "source": [
-    "###  Small scales on the PySM2 beta synchrotron template"
+    "# Small scales on the PySM 2 beta synchrotron template\n"
    ]
   },
   {
@@ -212,7 +212,7 @@
    "id": "d7a65d0b-eb10-452e-ac0a-d4a0490f14ad",
    "metadata": {},
    "source": [
-    "## Large scales"
+    "### Large scales"
    ]
   },
   {

--- a/docs/preprocess-templates/utils_gnilc_generate_map_spectralindex_Td.ipynb
+++ b/docs/preprocess-templates/utils_gnilc_generate_map_spectralindex_Td.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate GNILC spectral index and temperature maps\n"
+   ],
+   "id": "e97c58170ef0"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -9,7 +17,8 @@
     "import numpy as np\n",
     "import healpy as hp\n",
     "from pathlib import Path"
-   ]
+   ],
+   "id": "ddb21c064382"
   },
   {
    "cell_type": "code",
@@ -18,7 +27,8 @@
    "outputs": [],
    "source": [
     "output_dir = Path(\"production-data\") / \"dust_gnilc\""
-   ]
+   ],
+   "id": "c15f23bedbdd"
   },
   {
    "cell_type": "code",
@@ -27,7 +37,8 @@
    "outputs": [],
    "source": [
     "datadir = output_dir / \"raw\""
-   ]
+   ],
+   "id": "a036e0a6971e"
   },
   {
    "cell_type": "code",
@@ -41,7 +52,8 @@
    "source": [
     "output_nside = 2048\n",
     "name = \"beta\""
-   ]
+   ],
+   "id": "39faa21c6697"
   },
   {
    "cell_type": "code",
@@ -50,14 +62,16 @@
    "outputs": [],
    "source": [
     "output_lmax = int(min(2.5 * output_nside, 8192 * 2))"
-   ]
+   ],
+   "id": "6d7075b923e6"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Galactic mask"
-   ]
+    "### Galactic mask"
+   ],
+   "id": "bef0d3e66863"
   },
   {
    "cell_type": "code",
@@ -72,14 +86,16 @@
     "    )\n",
     "    == 1\n",
     ")"
-   ]
+   ],
+   "id": "a5bf06594b37"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Large scales"
-   ]
+    "### Large scales"
+   ],
+   "id": "52d94f38731f"
   },
   {
    "cell_type": "code",
@@ -91,7 +107,8 @@
     "    datadir / f\"gnilc_dust_largescale_template_{name}_alm_nside2048_lmax1024.fits.gz\",\n",
     "    hdu=1,\n",
     ")"
-   ]
+   ],
+   "id": "8295f556f137"
   },
   {
    "cell_type": "code",
@@ -100,14 +117,16 @@
    "outputs": [],
    "source": [
     "map_large_scale = hp.alm2map(alm_large_scale.astype(np.complex128), nside=output_nside)"
-   ]
+   ],
+   "id": "2b90c5ac912d"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Small scales modulation"
-   ]
+    "### Small scales modulation"
+   ],
+   "id": "750fe2db2e8d"
   },
   {
    "cell_type": "code",
@@ -118,14 +137,16 @@
     "modulate_alm = hp.read_alm(\n",
     "    datadir / f\"gnilc_dust_temperature_modulation_alms_lmax768.fits.gz\"\n",
     ").astype(np.complex128)"
-   ]
+   ],
+   "id": "a9e76ec26fcf"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Small scales"
-   ]
+    "### Small scales"
+   ],
+   "id": "694048261d40"
   },
   {
    "cell_type": "code",
@@ -136,7 +157,8 @@
     "cl_small_scale = hp.read_cl(\n",
     "    datadir / f\"gnilc_dust_small_scales_{name}_cl_lmax16384_2023.06.06.fits.gz\"\n",
     ")"
-   ]
+   ],
+   "id": "f4a85c3e6d8a"
   },
   {
    "cell_type": "code",
@@ -145,7 +167,8 @@
    "outputs": [],
    "source": [
     "len(cl_small_scale)"
-   ]
+   ],
+   "id": "1032856b4af4"
   },
   {
    "cell_type": "code",
@@ -154,7 +177,8 @@
    "outputs": [],
    "source": [
     "cl_small_scale"
-   ]
+   ],
+   "id": "d40b1d13091d"
   },
   {
    "cell_type": "code",
@@ -164,7 +188,8 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "plt.loglog(cl_small_scale)"
-   ]
+   ],
+   "id": "d10e511355e7"
   },
   {
    "cell_type": "code",
@@ -186,7 +211,8 @@
     "alm_small_scale = hp.almxfl(alm_small_scale, np.ones(int(2.5 * output_nside+1)))\n",
     "map_small_scale = hp.alm2map(alm_small_scale, nside=output_nside)\n",
     "assert np.isnan(map_small_scale).sum() == 0"
-   ]
+   ],
+   "id": "fffb67421d42"
   },
   {
    "cell_type": "code",
@@ -195,7 +221,8 @@
    "outputs": [],
    "source": [
     "map_small_scale = hp.alm2map(alm_small_scale, nside=output_nside)"
-   ]
+   ],
+   "id": "ba3e951de89d"
   },
   {
    "cell_type": "code",
@@ -204,7 +231,8 @@
    "outputs": [],
    "source": [
     "hp.mollview(map_small_scale)"
-   ]
+   ],
+   "id": "c9c60541edaa"
   },
   {
    "cell_type": "code",
@@ -213,7 +241,8 @@
    "outputs": [],
    "source": [
     "map_small_scale *= hp.alm2map(modulate_alm, output_nside)"
-   ]
+   ],
+   "id": "d86c70d3b65c"
   },
   {
    "cell_type": "code",
@@ -222,7 +251,8 @@
    "outputs": [],
    "source": [
     "hp.mollview(map_small_scale)"
-   ]
+   ],
+   "id": "4db22476050a"
   },
   {
    "cell_type": "code",
@@ -231,18 +261,20 @@
    "outputs": [],
    "source": [
     "hp.mollview(galactic_mask)"
-   ]
+   ],
+   "id": "c86e22874a32"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Combine scales\n",
+    "### Combine scales\n",
     "\n",
     "* Combine small and large scale maps\n",
     "* Transform from logpoltens to IQU\n",
     "* Write output map"
-   ]
+   ],
+   "id": "3154be7648a2"
   },
   {
    "cell_type": "code",
@@ -251,7 +283,8 @@
    "outputs": [],
    "source": [
     "map_total = map_large_scale + map_small_scale"
-   ]
+   ],
+   "id": "50047ddc8d41"
   },
   {
    "cell_type": "code",
@@ -260,7 +293,8 @@
    "outputs": [],
    "source": [
     "galplane_fix_mask = hp.read_map(datadir / \"gnilc_dust_galplane.fits.gz\", 3)"
-   ]
+   ],
+   "id": "adbcf1a1f5ec"
   },
   {
    "cell_type": "code",
@@ -269,7 +303,8 @@
    "outputs": [],
    "source": [
     "ext_number = {\"beta\":0, \"Td\":1}"
-   ]
+   ],
+   "id": "ef1560f6e44c"
   },
   {
    "cell_type": "code",
@@ -278,7 +313,8 @@
    "outputs": [],
    "source": [
     "galplane_fix = hp.read_map(datadir / \"gnilc_dust_beta_Td_galplane.fits.gz\", ext_number[name])"
-   ]
+   ],
+   "id": "268d83a93f92"
   },
   {
    "cell_type": "code",
@@ -288,7 +324,8 @@
    "source": [
     "map_total *= hp.ud_grade(galplane_fix_mask, output_nside)\n",
     "map_total += hp.ud_grade(galplane_fix * (1 - galplane_fix_mask), output_nside)"
-   ]
+   ],
+   "id": "430a14f1d39b"
   },
   {
    "cell_type": "code",
@@ -297,7 +334,8 @@
    "outputs": [],
    "source": [
     "hp.mollview(map_total - map_large_scale - map_small_scale, title=\"Effect of galactic plane fix\")"
-   ]
+   ],
+   "id": "51565cb88355"
   },
   {
    "cell_type": "code",
@@ -314,7 +352,8 @@
     "    dtype=np.float32,\n",
     "    overwrite=True,\n",
     ")"
-   ]
+   ],
+   "id": "b7943f217895"
   },
   {
    "cell_type": "code",
@@ -325,14 +364,16 @@
     "hp.mollview(map_large_scale, title=\"Large scale\")\n",
     "hp.mollview(map_small_scale, title=\"Small scale\")\n",
     "hp.mollview(map_total, title=\"Total\")"
-   ]
+   ],
+   "id": "0fae37f8b4bf"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [],
+   "id": "ed26d346cd08"
   }
  ],
  "metadata": {

--- a/docs/preprocess-templates/utils_synch_generate_map.ipynb
+++ b/docs/preprocess-templates/utils_synch_generate_map.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate synchrotron amplitude map\n"
+   ],
+   "id": "d8f246b766ea"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -9,7 +17,8 @@
     "import numpy as np\n",
     "import healpy as hp\n",
     "from pathlib import Path"
-   ]
+   ],
+   "id": "f7335ca1a069"
   },
   {
    "cell_type": "code",
@@ -20,7 +29,8 @@
     "datadir=Path(\"data/\")\n",
     "output_dir = Path(\"production-data/synch\")\n",
     "output_dir_raw = output_dir / \"raw\""
-   ]
+   ],
+   "id": "a76e33bd29bc"
   },
   {
    "cell_type": "code",
@@ -33,7 +43,8 @@
    "outputs": [],
    "source": [
     "output_nside = 2048"
-   ]
+   ],
+   "id": "13c78ea58101"
   },
   {
    "cell_type": "code",
@@ -42,7 +53,8 @@
    "outputs": [],
    "source": [
     "output_lmax = int(min(2.5*output_nside, 8192*2))"
-   ]
+   ],
+   "id": "6221c18f993b"
   },
   {
    "cell_type": "code",
@@ -52,14 +64,16 @@
    "source": [
     "comp = \"synch\"\n",
     "sub = \"template\""
-   ]
+   ],
+   "id": "3de296d6054c"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Large scales"
-   ]
+    "### Large scales"
+   ],
+   "id": "673fd732e2fa"
   },
   {
    "cell_type": "code",
@@ -68,7 +82,8 @@
    "outputs": [],
    "source": [
     "largescale_filename = [f\"{comp}_largescale_{sub}_logpoltens_alm_lmax128_2023.02.24.fits.gz\"]"
-   ]
+   ],
+   "id": "928aae16381e"
   },
   {
    "cell_type": "code",
@@ -77,7 +92,8 @@
    "outputs": [],
    "source": [
     "assert len(largescale_filename) == 1"
-   ]
+   ],
+   "id": "e1a6b95ab9f9"
   },
   {
    "cell_type": "code",
@@ -86,7 +102,8 @@
    "outputs": [],
    "source": [
     "largescale_filename = largescale_filename[0]"
-   ]
+   ],
+   "id": "dfc8351eba0b"
   },
   {
    "cell_type": "code",
@@ -95,7 +112,8 @@
    "outputs": [],
    "source": [
     "largescale_filename"
-   ]
+   ],
+   "id": "4aad9493b58a"
   },
   {
    "cell_type": "code",
@@ -104,7 +122,8 @@
    "outputs": [],
    "source": [
     "alm_log_pol_tens_large_scale = hp.read_alm(largescale_filename, hdu=(1,2,3))"
-   ]
+   ],
+   "id": "cd2adbac6877"
   },
   {
    "cell_type": "code",
@@ -113,7 +132,8 @@
    "outputs": [],
    "source": [
     "map_log_pol_tens_large_scale = hp.alm2map(alm_log_pol_tens_large_scale.astype(np.complex128), nside=output_nside)"
-   ]
+   ],
+   "id": "9f1ca3364f9a"
   },
   {
    "cell_type": "code",
@@ -122,14 +142,16 @@
    "outputs": [],
    "source": [
     "del alm_log_pol_tens_large_scale"
-   ]
+   ],
+   "id": "d5fdcf423c40"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Small scales modulation"
-   ]
+    "### Small scales modulation"
+   ],
+   "id": "0cb54dd56a8d"
   },
   {
    "cell_type": "code",
@@ -138,14 +160,16 @@
    "outputs": [],
    "source": [
     "modulate_alm = { k:hp.read_alm(output_dir_raw/f\"synch_{k}_modulation_alms_lmax64_2023.02.24.fits.gz\").astype(np.complex128) for k in [\"temperature\",\"polarization\"] }"
-   ]
+   ],
+   "id": "910f656b3be7"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Small scales"
-   ]
+    "### Small scales"
+   ],
+   "id": "15019f8fd423"
   },
   {
    "cell_type": "code",
@@ -154,7 +178,8 @@
    "outputs": [],
    "source": [
     "cl_small_scale = hp.read_cl(output_dir_raw / \"synch_small_scales_cl_lmax16384_2023.02.24.fits.gz\")"
-   ]
+   ],
+   "id": "3cfb90cc3dae"
   },
   {
    "cell_type": "code",
@@ -179,18 +204,20 @@
     "map_log_pol_tens_small_scale[0] *= hp.alm2map(modulate_alm[\"temperature\"], output_nside)\n",
     "map_log_pol_tens_small_scale[1:] *= hp.alm2map(modulate_alm[\"polarization\"], output_nside)\n",
     "assert np.isnan(map_log_pol_tens_small_scale).sum() == 0"
-   ]
+   ],
+   "id": "abd0558e95f5"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Combine scales\n",
+    "### Combine scales\n",
     "\n",
     "* Combine small and large scale maps\n",
     "* Transform from logpoltens to IQU\n",
     "* Write output map"
-   ]
+   ],
+   "id": "c45da79b4008"
   },
   {
    "cell_type": "code",
@@ -199,7 +226,8 @@
    "outputs": [],
    "source": [
     "map_log_pol_tens = map_log_pol_tens_large_scale + map_log_pol_tens_small_scale"
-   ]
+   ],
+   "id": "b7738e8634ec"
   },
   {
    "cell_type": "code",
@@ -208,7 +236,8 @@
    "outputs": [],
    "source": [
     "del map_log_pol_tens_large_scale, map_log_pol_tens_small_scale"
-   ]
+   ],
+   "id": "0aae26121905"
   },
   {
    "cell_type": "code",
@@ -217,7 +246,8 @@
    "outputs": [],
    "source": [
     "from pysm3.utils import log_pol_tens_to_map, add_metadata"
-   ]
+   ],
+   "id": "0b2054429ff0"
   },
   {
    "cell_type": "code",
@@ -226,14 +256,16 @@
    "outputs": [],
    "source": [
     "output_map = log_pol_tens_to_map(map_log_pol_tens)"
-   ]
+   ],
+   "id": "bc50e9b72481"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Galactic plane fix"
-   ]
+    "### Galactic plane fix"
+   ],
+   "id": "f677d0f26003"
   },
   {
    "cell_type": "code",
@@ -242,7 +274,8 @@
    "outputs": [],
    "source": [
     "galplane_fix = hp.read_map(output_dir_raw / \"synch_galplane.fits.gz\", (0, 1, 2, 3))"
-   ]
+   ],
+   "id": "7dbdde1c5738"
   },
   {
    "cell_type": "code",
@@ -252,7 +285,8 @@
    "source": [
     "output_map *= hp.ud_grade(galplane_fix[3], output_nside)\n",
     "output_map += hp.ud_grade(galplane_fix[:3] * (1 - galplane_fix[3]), output_nside)"
-   ]
+   ],
+   "id": "ffc73476bf3a"
   },
   {
    "cell_type": "code",
@@ -263,14 +297,16 @@
     "if output_nside < 4096:\n",
     "    hp.mollview((output_map - log_pol_tens_to_map(map_log_pol_tens))[0])\n",
     "    hp.mollview(output_map[0])"
-   ]
+   ],
+   "id": "944f675e1a45"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Write outputs"
-   ]
+    "### Write outputs"
+   ],
+   "id": "f1cd4c15fbf9"
   },
   {
    "cell_type": "code",
@@ -282,7 +318,8 @@
     "today = date.today()\n",
     "version = today.strftime(\"%Y.%m.%d\")\n",
     "version"
-   ]
+   ],
+   "id": "547b23bd7f59"
   },
   {
    "cell_type": "code",
@@ -291,7 +328,8 @@
    "outputs": [],
    "source": [
     "hp.write_map(output_dir / f\"synch_template_nside{output_nside}_{version}.fits\", output_map, dtype=np.float32, overwrite=True)"
-   ]
+   ],
+   "id": "860aa4c7aa3b"
   },
   {
    "cell_type": "code",
@@ -300,14 +338,16 @@
    "outputs": [],
    "source": [
     "add_metadata([output_dir / f\"synch_template_nside{output_nside}_{version}.fits\"], coord=\"G\", unit=\"uK_RJ\", ref_freq=\"23 GHz\")"
-   ]
+   ],
+   "id": "e1bca5588bf0"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [],
+   "id": "a33736913fdf"
   }
  ],
  "metadata": {

--- a/docs/preprocess-templates/utils_synch_generate_map_curvature.ipynb
+++ b/docs/preprocess-templates/utils_synch_generate_map_curvature.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compute synchrotron curvature harmonic coefficients\n"
+   ],
+   "id": "eb6cb873e076"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -9,7 +17,8 @@
     "import numpy as np\n",
     "import healpy as hp\n",
     "from pathlib import Path"
-   ]
+   ],
+   "id": "5141505c4e2c"
   },
   {
    "cell_type": "code",
@@ -20,7 +29,8 @@
     "datadir=Path(\"data/\")\n",
     "output_dir = Path(\"production-data/synch\")\n",
     "output_dir_raw = output_dir / \"raw\""
-   ]
+   ],
+   "id": "cb1010e83006"
   },
   {
    "cell_type": "code",
@@ -29,7 +39,8 @@
    "outputs": [],
    "source": [
     "output_nside = 8192"
-   ]
+   ],
+   "id": "55fa7162464f"
   },
   {
    "cell_type": "code",
@@ -38,14 +49,16 @@
    "outputs": [],
    "source": [
     "output_lmax = min(int(2.5 * output_nside), 8192 * 2)"
-   ]
+   ],
+   "id": "1a051f2d1256"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## $a_{\\ell m}$"
-   ]
+    "### $a_{\\ell m}$"
+   ],
+   "id": "acf92cf96d6b"
   },
   {
    "cell_type": "code",
@@ -57,7 +70,8 @@
     "    output_dir_raw / f\"synch_curvature_alm_nside8192_lmax16384.fits\",\n",
     "    hdu=1,\n",
     ")"
-   ]
+   ],
+   "id": "aa526bb3e073"
   },
   {
    "cell_type": "code",
@@ -67,7 +81,8 @@
    "source": [
     "alm_clip = hp.almxfl(alm, np.ones(output_lmax + 1))\n",
     "del alm"
-   ]
+   ],
+   "id": "a959a3d53294"
   },
   {
    "cell_type": "code",
@@ -76,7 +91,8 @@
    "outputs": [],
    "source": [
     "output_map = hp.alm2map(alm_clip.astype(np.complex128), nside=output_nside)"
-   ]
+   ],
+   "id": "69ff7deddd4c"
   },
   {
    "cell_type": "code",
@@ -85,7 +101,8 @@
    "outputs": [],
    "source": [
     "output_filename = output_dir / f\"synch_curvature_nside{output_nside}.fits\""
-   ]
+   ],
+   "id": "5ac6dc67d883"
   },
   {
    "cell_type": "code",
@@ -94,7 +111,8 @@
    "outputs": [],
    "source": [
     "hp.write_map(output_filename, output_map, dtype=np.float32, overwrite=True)"
-   ]
+   ],
+   "id": "2a9fba3c8ebb"
   },
   {
    "cell_type": "code",
@@ -103,7 +121,8 @@
    "outputs": [],
    "source": [
     "from pysm3.utils import add_metadata"
-   ]
+   ],
+   "id": "f7be29d0a6de"
   },
   {
    "cell_type": "code",
@@ -112,7 +131,8 @@
    "outputs": [],
    "source": [
     "add_metadata([output_filename], coord=\"G\", unit=\"\", ref_freq=\"23 GHz\", ell_max=str(output_lmax))"
-   ]
+   ],
+   "id": "5dd2723b8631"
   }
  ],
  "metadata": {

--- a/docs/preprocess-templates/utils_synch_generate_map_spectralindex.ipynb
+++ b/docs/preprocess-templates/utils_synch_generate_map_spectralindex.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate synchrotron spectral index map\n"
+   ],
+   "id": "a80007f234a5"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -9,7 +17,8 @@
     "import numpy as np\n",
     "import healpy as hp\n",
     "from pathlib import Path"
-   ]
+   ],
+   "id": "3a79602dbb73"
   },
   {
    "cell_type": "code",
@@ -20,7 +29,8 @@
     "datadir=Path(\"data/\")\n",
     "output_dir = Path(\"production-data/synch\")\n",
     "output_dir_raw = output_dir / \"raw\""
-   ]
+   ],
+   "id": "bc120a52e495"
   },
   {
    "cell_type": "code",
@@ -33,7 +43,8 @@
    "outputs": [],
    "source": [
     "output_nside = 2048"
-   ]
+   ],
+   "id": "1f455305d060"
   },
   {
    "cell_type": "code",
@@ -42,14 +53,16 @@
    "outputs": [],
    "source": [
     "output_lmax = int(min(2.5 * output_nside, 8192 * 2))"
-   ]
+   ],
+   "id": "8ed458499ed2"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Large scales"
-   ]
+    "### Large scales"
+   ],
+   "id": "e59950616873"
   },
   {
    "cell_type": "code",
@@ -61,7 +74,8 @@
     "    output_dir_raw / f\"synch_largescale_beta_alm_nside512_lmax768.fits.gz\",\n",
     "    hdu=1,\n",
     ")"
-   ]
+   ],
+   "id": "9190d17dea8d"
   },
   {
    "cell_type": "code",
@@ -70,14 +84,16 @@
    "outputs": [],
    "source": [
     "map_large_scale = hp.alm2map(alm_large_scale.astype(np.complex128), nside=output_nside)"
-   ]
+   ],
+   "id": "76faf8f23019"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Small scales modulation"
-   ]
+    "### Small scales modulation"
+   ],
+   "id": "5eff1698a440"
   },
   {
    "cell_type": "code",
@@ -88,14 +104,16 @@
     "modulate_alm = hp.read_alm(\n",
     "    output_dir_raw / f\"synch_amplitude_modulation_alms_lmax768.fits.gz\"\n",
     ").astype(np.complex128)"
-   ]
+   ],
+   "id": "4d387c248da0"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Small scales"
-   ]
+    "### Small scales"
+   ],
+   "id": "0f84fa682230"
   },
   {
    "cell_type": "code",
@@ -106,7 +124,8 @@
     "cl_small_scale = hp.read_cl(\n",
     "    output_dir_raw / f\"synch_small_scales_beta_cl_lmax16384.fits.gz\"\n",
     ")"
-   ]
+   ],
+   "id": "e61db6ef2447"
   },
   {
    "cell_type": "code",
@@ -129,17 +148,19 @@
     "map_small_scale = hp.alm2map(alm_small_scale, nside=output_nside)\n",
     "map_small_scale *= hp.alm2map(modulate_alm, output_nside)\n",
     "assert np.isnan(map_small_scale).sum() == 0"
-   ]
+   ],
+   "id": "54b741e82519"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Combine scales\n",
+    "### Combine scales\n",
     "\n",
     "* Combine small and large scale maps\n",
     "* Write output map"
-   ]
+   ],
+   "id": "ff8479d7d554"
   },
   {
    "cell_type": "code",
@@ -148,7 +169,8 @@
    "outputs": [],
    "source": [
     "output_map = map_large_scale + map_small_scale - 3.1"
-   ]
+   ],
+   "id": "47dd6ec1299f"
   },
   {
    "cell_type": "code",
@@ -157,7 +179,8 @@
    "outputs": [],
    "source": [
     "hp.write_map(output_dir / f\"synch_beta_nside{output_nside}.fits\", output_map, dtype=np.float32, overwrite=True)"
-   ]
+   ],
+   "id": "f4e63d9f1415"
   },
   {
    "cell_type": "code",
@@ -166,7 +189,8 @@
    "outputs": [],
    "source": [
     "from pysm3.utils import add_metadata"
-   ]
+   ],
+   "id": "e8e4c34b81c9"
   },
   {
    "cell_type": "code",
@@ -175,7 +199,8 @@
    "outputs": [],
    "source": [
     "add_metadata([output_dir / f\"synch_beta_nside{output_nside}.fits\"], coord=\"G\", unit=\"\", ref_freq=\"23 GHz\", ell_max=str(output_lmax))"
-   ]
+   ],
+   "id": "aa60cd252eac"
   },
   {
    "cell_type": "code",
@@ -186,7 +211,8 @@
     "hp.mollview(map_large_scale, title=\"Large scale\")\n",
     "hp.mollview(map_small_scale, title=\"Small scale\")\n",
     "hp.mollview(output_map, title=\"Total\")"
-   ]
+   ],
+   "id": "dee9284c9425"
   }
  ],
  "metadata": {

--- a/docs/preprocess-templates/verify_templates/verify_templates_dust.ipynb
+++ b/docs/preprocess-templates/verify_templates/verify_templates_dust.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Verify dust templates\n"
+   ],
+   "id": "f8cf04d96ecb"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "1a15c079-f15d-42fb-b66e-77843711d11a",

--- a/docs/preprocess-templates/verify_templates/verify_templates_synch.ipynb
+++ b/docs/preprocess-templates/verify_templates/verify_templates_synch.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Verify synchrotron templates\n"
+   ],
+   "id": "2c5d5abfde25"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "1a15c079-f15d-42fb-b66e-77843711d11a",

--- a/docs/preprocess-templates/websky_sources_high_flux_catalog.ipynb
+++ b/docs/preprocess-templates/websky_sources_high_flux_catalog.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WebSky bright source catalog workflow\n"
+   ],
+   "id": "aef8d96ab819"
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "0ed31a46-d481-4958-af82-3889e2f6b80a",

--- a/docs/pysm_methods_author_contributions.rst
+++ b/docs/pysm_methods_author_contributions.rst
@@ -1,6 +1,6 @@
-===============================
+================================
 PySM Methods Paper Contributions
-===============================
+================================
 
 **Julian Borrill**: Coordinated simulation efforts with early versions of the models across multiple collaborations, contributed to the writing of Section 1
 

--- a/src/pysm3/__init__.py
+++ b/src/pysm3/__init__.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 import warnings
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 warnings.filterwarnings("ignore", message="may indicate binary incompatibility")
 

--- a/src/pysm3/models/dipole.py
+++ b/src/pysm3/models/dipole.py
@@ -44,8 +44,8 @@ class CMBDipole:
 
     where θ is the angle between the dipole direction and the line of sight.
 
-    Reference
-    ---------
+    References
+    ----------
     For the best-fit parameters, see Table 1 of
     "Planck intermediate results. LVII. Joint Planck LFI and HFI data processing"
     https://arxiv.org/pdf/2007.04997.pdf


### PR DESCRIPTION
## Summary
- expand README release workflow with a uv-based checklist and token guidance
- make the CMBDipole docstring numpydoc compliant so it shows up cleanly in the API docs
- resolve Sphinx warnings by restructuring notebook toctrees, adding titles/anchors/ids, and updating the doc config

## Testing
- tox -e build_docs
