### PR TITLE
Add non-Gaussian multifractal field realizations

### DIFF
--- a/src/pysm3/data/presets.cfg
+++ b/src/pysm3/data/presets.cfg
@@ -186,6 +186,27 @@ color_correction = 0.911
 unit_layers = "MJy/sr"
 unit_mbb_temperature = "K"
 max_nside = 2048
+[d13]
+class = "ModifiedBlackBodyRealization"
+amplitude_modulation_temp_alm = "dust_gnilc/raw/gnilc_dust_temperature_modulation_alms_lmax768.fits.gz"
+amplitude_modulation_pol_alm = "dust_gnilc/raw/gnilc_dust_polarization_modulation_alms_lmax768.fits.gz"
+largescale_alm = "dust_gnilc/raw/gnilc_dust_largescale_template_logpoltens_alm_nside2048_lmax1024_complex64.fits.gz"
+small_scale_cl = "dust_gnilc/raw/gnilc_dust_small_scales_logpoltens_cl_lmax16384.fits.gz"
+largescale_alm_mbb_index = "dust_gnilc/raw/gnilc_dust_largescale_template_beta_alm_nside2048_lmax1024.fits.gz"
+small_scale_cl_mbb_index = "dust_gnilc/raw/gnilc_dust_small_scales_beta_cl_lmax16384_2023.06.06.fits.gz"
+largescale_alm_mbb_temperature = "dust_gnilc/raw/gnilc_dust_largescale_template_Td_alm_nside2048_lmax1024.fits.gz"
+small_scale_cl_mbb_temperature = "dust_gnilc/raw/gnilc_dust_small_scales_Td_cl_lmax16384_2023.06.06.fits.gz"
+freq_ref = "353 GHz"
+# Remove the galplane_fix option to skip applying the galactic plane fix
+galplane_fix = "dust_gnilc/raw/gnilc_dust_galplane.fits.gz"
+galplane_fix_beta_Td = "dust_gnilc/raw/gnilc_dust_beta_Td_galplane.fits.gz"
+# Configuration for reproducing d10
+# seeds = [8192,777,888]
+# synalm_lmax = 16384
+max_nside = 8192
+Lplus = 30.0
+Hplus = 0.5
+lamb = 0.25
 [s0]
 class = "PowerLaw"
 map_I = "pysm_2/synch_t_new.fits"
@@ -260,7 +281,7 @@ small_scale_cl_pl_index = "synch/raw/synch_small_scales_beta_cl_lmax16384.fits.g
 freq_ref = "23 GHz"
 max_nside = 8192
 # Remove the galplane_fix option to skip applying the galactic plane fix
-galplane_fix = "synch/raw/synch_galplane.fits.gz"
+# galplane_fix = "synch/raw/synch_galplane.fits.gz"
 # Configuration for reproducing s5
 # seeds = [555,444]
 # synalm_lmax = 16384
@@ -274,6 +295,25 @@ spectral_curvature = "synch/synch_curvature_nside{nside}_2023.02.17.fits"
 freq_curve = "23 GHz"
 max_nside = 8192
 available_nside = [2048, 4096, 8192]
+[s8]
+class = "PowerLawRealization"
+largescale_alm = "synch/raw/synch_largescale_template_logpoltens_alm_lmax128_2023.02.24.fits.gz"
+amplitude_modulation_temp_alm = "synch/raw/synch_temperature_modulation_alms_lmax64_2023.02.24.fits.gz"
+amplitude_modulation_pol_alm = "synch/raw/synch_polarization_modulation_alms_lmax64_2023.02.24.fits.gz"
+amplitude_modulation_beta_alm = "synch/raw/synch_amplitude_modulation_alms_lmax768.fits.gz"
+small_scale_cl = "synch/raw/synch_small_scales_cl_lmax16384_2023.02.24.fits.gz"
+largescale_alm_pl_index = "synch/raw/synch_largescale_beta_alm_nside512_lmax768.fits.gz"
+small_scale_cl_pl_index = "synch/raw/synch_small_scales_beta_cl_lmax16384.fits.gz"
+freq_ref = "23 GHz"
+max_nside = 8192
+Lplus = 16.0
+Hplus = 0.5
+lamb = 0.25
+# Remove the galplane_fix option to skip applying the galactic plane fix
+# galplane_fix = "synch/raw/synch_galplane.fits.gz"
+# Configuration for reproducing s5
+seeds = [555,444]
+# synalm_lmax = 16384
 [f1]
 class = "PowerLaw"
 map_I = "pysm_2/ff_t_new.fits"

--- a/src/pysm3/models/power_law_realization.py
+++ b/src/pysm3/models/power_law_realization.py
@@ -25,6 +25,9 @@ class PowerLawRealization(PowerLaw):
         synalm_lmax=None,
         has_polarization=True,
         map_dist=None,
+        lamb=None,
+        Lplus=None,
+        Hplus=None,
     ):
         """PowerLaw model with stochastic small scales
 
@@ -103,50 +106,149 @@ class PowerLawRealization(PowerLaw):
             u.dimensionless_unscaled
         )
         self.nside = int(nside)
+
+        if lamb is None or Lplus is None or Hplus is None:
+            print('generating monofractal field')
+            small_scale = self.draw_realization(synalm_lmax, seeds)
+        else:
+            print('generating multifractal field')
+            small_scale = self.draw_mff_realization(lamb, Lplus, Hplus, synalm_lmax, seeds)
+        self.f_real = small_scale.copy()
         (
             self.I_ref,
             self.Q_ref,
             self.U_ref,
             self.pl_index,
-        ) = self.draw_realization(synalm_lmax, seeds)
+        ) = self.modulate_small_scales(small_scale, synalm_lmax, seeds)
 
-    def draw_realization(self, synalm_lmax=None, seeds=None):
+    def draw_model_realization(self, H1, L1, nside, seed=0):
+        """Realize noise from a model power spectrum"""
+        np.random.seed(seed)
+        lmax = 3*nside - 1
+        alm_size = hp.Alm.getsize(lmax)
+        ell = np.arange(lmax)
+        # Random phases
+        phases = np.random.uniform(0., 2.*np.pi, alm_size)
+        phases = np.cos(phases) + 1j * np.sin(phases)
+        # Model power spectrum
+        fl = (ell**2 + L1**2)**(-H1)
+        flm = hp.almxfl(phases, fl)
+        flm[np.isnan(flm)|np.isinf(flm)] = 0. + 1j * 0.
+        f_real = hp.alm2map(flm, nside=nside, lmax=lmax)
+        # De-mean and standardize
+        f_real = f_real - np.nanmean(f_real)
+        curr_var = np.nanmean(np.abs(f_real)**2)
+        f_real = f_real / np.sqrt(curr_var)
+        return f_real.copy()
 
+    def draw_corr_gauss_realization(self, Cl, nside, seed=0, normalize=False):
+        """Realize noise from given power spectra Cl"""
+        np.random.seed(seed)
+        lmax = 3*nside - 1
+        # Synthesize alms
+        flms = hp.synalm(Cl, lmax=lmax, new=True)
+        N_fields = np.shape(flms)[0]
+        for i in range(N_fields):
+            flms[i][np.isnan(flms[i])|np.isinf(flms[i])] = 0. + 1j * 0.
+        f_reals = hp.alm2map(flms, nside=nside, lmax=lmax)
+        # De-mean and standardize
+        if normalize:
+            for i in range(N_fields):
+                f_reals[i] = f_reals[i] - np.nanmean(f_reals[i])
+                curr_var = np.nanmean(np.abs(f_reals[i])**2)
+                f_reals[i] = f_reals[i] / np.sqrt(curr_var)
+        return f_reals.copy()
+
+    def draw_mff_realization(self, lamb, L_plus=100., H_plus=0., synalm_lmax=None, seeds=None):
+        """Realize multifractal field"""
         if seeds is None:
             seeds = (None, None)
-
         if synalm_lmax is None:
             synalm_lmax = int(min(16384, 2.5 * self.nside))
-
         output_lmax = int(min(synalm_lmax, 2.5 * self.nside))
+        np.random.seed(seeds[0])
+        Cl = list(self.small_scale_cl.value)
+        ## Generate correlated white noise
+        phi_w = self.draw_corr_gauss_realization(Cl/Cl[0], self.nside, seeds[0], normalize=False)
+        if len(np.shape(phi_w)) > 1:
+            N_fields = np.shape(phi_w)[0]
+        else:
+            N_fields = 1
+        ## Generate correlated Gaussian noise
+        omegas = []
+        for i in range(N_fields):
+            omegas.append(self.draw_model_realization(H_plus, L_plus, self.nside, seeds[1]))
+        ## Generate volatility (log-normal) field
+        sigmas = [(np.exp(np.sqrt(lamb) * omegas[i])).copy() for i in range(N_fields)]
+        ## Symmetrize the field
+        dhs = [(sigmas[i] * phi_w[i]).copy() for i in range(N_fields)]
+        dh_alms = hp.map2alm(dhs, lmax=output_lmax)
+        # Use fractional integration from small scale Cl
+        filter_ell = [np.sqrt(Cl) for Cl in self.small_scale_cl]
+        f_alm = [hp.almxfl(dh_alms[i], filter_ell[i]) for i in range(N_fields)]
+        # Ensure no bad values generated
+        for _alm in f_alm:
+            _alm[np.isnan(_alm)|np.isinf(_alm)] = 0. + 1j * 0.
+        # Map to output lmax
+        f_alm = [hp.almxfl(f_alm[i], np.ones(output_lmax+1)) for i in range(N_fields)]
+        f_real = hp.alm2map(f_alm, nside=self.nside, lmax=output_lmax)
+        for i in range(N_fields):
+            f_real[i] = f_real[i] - np.nanmean(f_real[i])
+            curr_var = np.nanmean(np.abs(f_real[i])**2)
+            ell = np.float64(np.arange(len(Cl[i])))
+            var2 = np.nansum((2.*ell+1.)*Cl[i])/(4.*np.pi)
+            f_real[i] = np.sqrt(var2) * f_real[i] / np.sqrt(curr_var)
 
+        return np.float64(f_real)
+
+    def draw_realization(self, synalm_lmax=None, seeds=None):
+        if seeds is None:
+            seeds = (None, None)
+        if synalm_lmax is None:
+            synalm_lmax = int(min(16384, 2.5 * self.nside))
+        output_lmax = int(min(synalm_lmax, 2.5 * self.nside))
         np.random.seed(seeds[0])
 
+        ## Synthesize Cl
+        # tt, ee, bb, te
+        # -> t, e, b
         alm_small_scale = hp.synalm(
             list(self.small_scale_cl.value),
             lmax=synalm_lmax,
             new=True,
         )
-
         alm_small_scale = [
             hp.almxfl(each, np.ones(output_lmax + 1)) for each in alm_small_scale
         ]
+        # t, e, b
+        # -> i, q, u
         map_small_scale = hp.alm2map(alm_small_scale, nside=self.nside)
+        return map_small_scale
 
-        # need later for beta
+    def modulate_small_scales(self, map_small_scale, synalm_lmax=None, seeds=None):
+        if seeds is None:
+            seeds = (None, None)
+        if synalm_lmax is None:
+            synalm_lmax = int(min(16384, 2.5 * self.nside))
+        output_lmax = int(min(synalm_lmax, 2.5*self.nside))
+        np.random.seed(seeds[0])
+
+        # NOTE: need later for beta
         modulate_map_I = hp.alm2map(self.modulate_alm[0].value, self.nside)
-
+        ## Modulate the small-scale fluctuations by the modulation maps
         map_small_scale[0] *= modulate_map_I
         map_small_scale[1:] *= hp.alm2map(self.modulate_alm[1].value, self.nside)
-
         if len(self.modulate_alm) == 3:
+            ## If modulate_alm == 3, then the third index is the beta, rather than the first
             modulate_map_I = hp.alm2map(self.modulate_alm[2].value, self.nside)
 
+        ## Add large scale/mean field
         map_small_scale += hp.alm2map(
             self.template_largescale_alm.value,
             nside=self.nside,
         )
 
+        ## Convert to IQU
         output_IQU = (
             utils.log_pol_tens_to_map(map_small_scale)
             * self.template_largescale_alm.unit
@@ -171,6 +273,7 @@ class PowerLawRealization(PowerLaw):
             new=True,
         )
 
+        ## Generate a Gaussian power law field
         alm_small_scale = hp.almxfl(alm_small_scale, np.ones(output_lmax + 1))
         pl_index = hp.alm2map(alm_small_scale, nside=self.nside) * output_unit
         pl_index *= modulate_map_I


### PR DESCRIPTION
## Add non-Gaussian (multifractal) field realizations

**Feel free to reach out if you have any questions, concerns, or suggestions for improvements!**

1. Modify `PowerLawRealization` and `ModifiedBlackBodyRealization` for the synthesis of a non-Gaussian (multifractal) small-scale field of $i_\delta, q_\delta, u_\delta$.
3. Add models `[s8]` and `[d13]` which extend `[s6]` and `[d11]` respectively.

The original Gaussian realization (of $i_\delta, q_\delta, u_\delta$) is still preserved by setting the parameters `Lplus=None`, `Hplus=None`, and `lamb=None`.

Currently, I have "vibes-based" chosen values for `Lplus`, `Hplus`, and `lamb` -- further work should be done in constraining these parameters off observations or simulations (or finding them if they already exist in literature).

#### The Model Description:
A Gaussian field is synthesized in harmonic space with a given power spectrum $C_\ell$ via,
$a_{\ell,m} = \sqrt{C_\ell} \phi_{\ell,m}$
where $\phi_{\ell,m}$ is uniformly sampled phases (white noise).

We synthesize a non-Gaussian multifractal field by the following:
1. Synthesize a Gaussian field on the sphere $f(\gamma)$ in Harmonic space using $a_{\ell,m} = (\ell^2 + L_+)^{-H_+} \phi_{\ell,m}$ where $\phi_{\ell,m}$ is white noise and $\sqrt{C_\ell} = (\ell^2 + L_+)^{-H_+}$.
2. In real-space, scale the field by $\sqrt{\lambda}$ and take its exponential: $\sigma(\gamma) = e^{\sqrt{\lambda} f(\gamma)}$. This forms a log-normal field $>0$.
3. In real-space, multiply the log-normal field by white noise to get non-Gaussian correlated white noise: $\phi^{\mathrm{ng}}(\gamma) = \sigma(\gamma) \phi(\gamma)$ where $\phi(\gamma)$ is white noise with the same variance as $ \sigma(\gamma)$.
4. Take the transform of $\phi^{\mathrm{ng}}(\gamma) \rightarrow \phi_{\ell,m}^{\mathrm{ng}}$ and multiply it by your desired power spectrum $b_{\ell,m} = \sqrt{C_\ell} \phi_{\ell,m}^{\mathrm{ng}}$.

This largely follows the steps discussed in [https://doi.org/10.1103/PhysRevResearch.7.L012003](https://doi.org/10.1103/PhysRevResearch.7.L012003) and [https://doi.org/10.1103/PhysRevE.64.026103](https://doi.org/10.1103/PhysRevE.64.026103)

The model has 3 free parameters: $L_+$ (`Lplus` ), $H_+$ (`Hplus`), and $\lambda$ (`lamb`) that control the strength of the non-Gaussianity.
- $L_+$: Controls the largest scale of the spatial extent of the extreme non-Gaussian features. At $\ell \gg L_+$, the field is Gaussian.
- $H_+$: Controls the amplitude (and the scale) of the non-Gaussian features -- leave at 0.5.
- $\lambda$: Controls the strength and cascade of the non-Gaussianity. $\lambda \rightarrow 0$ gives Gaussian behaviour.

For large-enough $\lambda$, the power-spectrum will have a modified power-law -- which may explain some of the discrepancy seen below.

See example notebooks in: [https://github.com/mab68/mff_pysm_example](https://github.com/mab68/mff_pysm_example)

#### Dust Model
Example region, comparing PR3 Planck 353 GHZ observation to `d11` and `d13` for $I$.
<img width="2284" height="870" alt="output" src="https://github.com/user-attachments/assets/c7571c63-17bd-42ec-834a-5ce8eaccc921" />
Example region, comparing PR3 Planck 353 GHZ observation to `d11` and `d13` for $P = \sqrt{Q^2 + U^2}$.
<img width="2269" height="870" alt="output" src="https://github.com/user-attachments/assets/c59bede5-1faf-4168-bb3f-6c13917fbdab" />

Comparing spectra of `d11` and `d13` (with a $10^\circ$ apodized galactic plane mask):
<img width="1555" height="473" alt="output" src="https://github.com/user-attachments/assets/1afc50e2-2beb-4c87-811e-5ab23163394f" />
<img width="1566" height="483" alt="output" src="https://github.com/user-attachments/assets/cc136bd4-0e77-4578-806c-66a1f8d51246" />

#### Synchrotron Model
Example region, comparing `s6` and `s8` for $I$.
<img width="1587" height="870" alt="output" src="https://github.com/user-attachments/assets/0ff2b36e-92e6-4237-b91b-18989f0dc881" />
Example region, comparing `s6` and `s8` for $P$.
<img width="1587" height="870" alt="output" src="https://github.com/user-attachments/assets/d106f52a-9c7b-4081-8dfd-b2515586741c" />

Comparing spectra of `s8` with `s6` (with a $10^\circ$ apodized galactic plane mask):
<img width="1555" height="473" alt="output" src="https://github.com/user-attachments/assets/ee9a26f2-425f-4d4f-b14c-92cd5380d39e" />
<img width="1566" height="483" alt="output" src="https://github.com/user-attachments/assets/10f54903-144b-4932-b74f-23b41201b7d7" />

