### PR TITLE
Set SciPy minimum to 1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ maintainers = [
 dependencies = [
     "astropy",
     "h5py",
-    "scipy < 1.15",
+    "scipy >= 1.10, < 1.15",
     "healpy >= 1.16.0",
     "importlib_metadata;python_version<'3.8'",
     "numba",


### PR DESCRIPTION
## Summary
- set a SciPy lower bound (>= 1.10) while keeping the existing < 1.15 cap

## Rationale
uv selects the lowest compatible version by default. With only an upper bound, it picks SciPy 1.6.1, which falls back to a source build and fails on modern Python (missing distutils/headers). A minimum of 1.10 ensures a wheel-compatible version without over-constraining users.

## Testing
- not run (dependency change only)
