### PR TITLE
Free-free f2 notebook: fix lmax/log transform and smooth transition

### DIFF
--- a/docs/preprocess-templates/freefree/small_scale_freefree_f2_generate_template.ipynb
+++ b/docs/preprocess-templates/freefree/small_scale_freefree_f2_generate_template.ipynb
@@ -23,11 +23,11 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "The input free–free tracer used here is the emission-measure (EM) mean/variance map from the all-sky Galactic Faraday/electron-density reconstruction of Hutschenreuter et al. 2024. \n",
+    "The input free–free tracer used here is the emission-measure (EM) mean/variance map from the all-sky Galactic Faraday/electron-density reconstruction of Hutschenreuter et al. 2024.\n",
     "\n",
     "Throughout this notebook, we refer to this map as the HE map, following Hutschenreuter & Enßlin (2020), which presented the original reconstruction framework on which the later analysis is based.\n",
     "\n",
-    "We use the FITS product EM_mean_std.fits provided on Zenodo:  https://zenodo.org/records/10523170/files/EM_mean_std.fits?download=1  ￼\n"
+    "We use the FITS product EM_mean_std.fits provided on Zenodo: https://zenodo.org/records/10523170/files/EM_mean_std.fits?download=1\n"
    ]
   },
   {


### PR DESCRIPTION
Changes on top of `freefree_f2_fazlurahman`:

- Fix HEALPix `lmax` off-by-one for `hp.synfast`.
- Make log transform consistent and robust to zeros (data-driven `eps` + reporting cell).
- Make modulation map computation robust and fix output filename/units.
- Set `OMP_NUM_THREADS` early without hard-coding.
- Improve large/small-scale transition using power-conserving harmonic cross-fade filters.