### PR TITLE
Update spherical_harmonics.py

### DIFF
--- a/src/pysm3/utils/spherical_harmonics.py
+++ b/src/pysm3/utils/spherical_harmonics.py
@@ -28,7 +28,7 @@ def apply_smoothing_and_coord_transform(
     map2alm_lsq_maxiter=None,
     map_dist=None,
 ):
-    """Apply smoothing and coordinate rotation to an input map
+    r"""Apply smoothing and coordinate rotation to an input map
 
     it applies the `healpy.smoothing` Gaussian smoothing kernel if `map_dist`
     is None, otherwise applies distributed smoothing with `libsharp`.


### PR DESCRIPTION
Just added an r before """Apply smoothing ...
to avoid prevent errors like :

/pysm/src/pysm3/utils/spherical_harmonics.py:31: SyntaxWarning: invalid escape sequence '\e'
  """Apply smoothing and coordinate rotation to an input map