### PR TITLE
Clean up packaging metadata and build config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ See the `documentation <https://pysm3.readthedocs.io/en/latest/#installation>`_
 
 * Install with ``pip install .`` or with ``pip install .[test]`` to also install the requirements for running tests
 * Optionally, if you have an MPI environment available and you would like to test the MPI capabilities of PySM, install ``mpi4py`` and ``libsharp``, check the documentation link above for more details.
-* This repository uses Git LFS for Jupyter notebook files (*.ipynb). Ensure Git LFS is installed and run ``git lfs pull`` after cloning to fetch large files.
+* This repository uses Git LFS for Jupyter notebook files (``*.ipynb``). Ensure Git LFS is installed and run ``git lfs pull`` after cloning to fetch large files.
 * Check code style with ``uv run flake8 src/pysm3 --count --max-line-length=100``
 * Test with ``uv run pytest -v``
 * Building docs requires ``pandoc``, not the python package, the actual ``pandoc`` command line tool, install it with conda or your package manager

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ Release
 
        uv venv .venv
        uv pip install --python .venv/bin/python pip hatch
+       uv pip install --python .venv/bin/python -e .[test]
 
    Activate it for the remaining steps with ``source .venv/bin/activate``.
 4. Run the test suite (at least ``pytest``) to verify the release build.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -209,6 +209,7 @@ high-resolution templates shipped with PySM.
   Synchrotron curvature modelling <preprocess-templates/synchrotron_curvature>
   Log-pol-tens formalism notebook <preprocess-templates/synchrotron_template_logpoltens>
   WebSky bright source catalog workflow <preprocess-templates/websky_sources_high_flux_catalog>
+  Compare WebSky and Agora SZ templates <preprocess-templates/verify_templates/compare_websky_agora_sz>
   Verify dust templates <preprocess-templates/verify_templates/verify_templates_dust>
   Verify synchrotron templates <preprocess-templates/verify_templates/verify_templates_synch>
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -136,8 +136,6 @@ Cosmic Infrared Background
 Sunyaev–Zeldovich emission
 ==========================
 
-.. _halfdome:
-
 * `Comparison of WebSky and Agora SZ templates <preprocess-templates/verify_templates/compare_websky_agora_sz.ipynb>`_
 
 - **tsz1**: Thermal SZ emission from WebSky 0.4. Available at $N_{side}=8192$. For more details see :ref:`websky`.
@@ -146,7 +144,7 @@ Sunyaev–Zeldovich emission
 
 - **tsz3**: Lensed Thermal SZ emission from the `Agora simulations <https://doi.org/10.1093/mnras/stae1031>`_. Available at $N_{side}=8192$.
 
-- **tsz4**: Thermal SZ emission from the `HalfDome simulations <https://doi.org/10.48550/arXiv.2407.17462>`_ 0.1 (generated using xgpaint with Battaglia16 profiles). Eleven realizations available at $N_{side}=8192$ by overriding the `template_name` with seeds: 100 (default), 102, 104, 106, 108, 110, 112, 114, 116, 118, 120. For example: `halfdome/0.1/tsz/y_b16_halo_res1_s102.fits`. For more details see :ref:`halfdome`.
+- **tsz4**: Thermal SZ emission from the `HalfDome simulations <https://doi.org/10.48550/arXiv.2407.17462>`_ 0.1 (generated using xgpaint with Battaglia16 profiles). Eleven realizations available at $N_{side}=8192$ by overriding the `template_name` with seeds: 100 (default), 102, 104, 106, 108, 110, 112, 114, 116, 118, 120. For example: `halfdome/0.1/tsz/y_b16_halo_res1_s102.fits`.
 
 - **ksz1**: Kinetic SZ emission from WebSky 0.4. Available at $N_{side}=4096$. For more details see :ref:`websky`.
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -136,6 +136,8 @@ Cosmic Infrared Background
 Sunyaev–Zeldovich emission
 ==========================
 
+.. _halfdome:
+
 * `Comparison of WebSky and Agora SZ templates <preprocess-templates/verify_templates/compare_websky_agora_sz.ipynb>`_
 
 - **tsz1**: Thermal SZ emission from WebSky 0.4. Available at $N_{side}=8192$. For more details see :ref:`websky`.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,6 @@ numba
 numpy
 healpy
 ipykernel
-pandoc
 sphinx-astropy
 sphinx-math-dollar
 nbsphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "h5py",
     "scipy >= 1.10, < 1.15",
     "healpy >= 1.16.0",
-    "importlib_metadata;python_version<'3.8'",
     "numba",
     "numpy >= 1.21",
     "toml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,6 @@ version-file = "src/pysm3/_version.py"
 include = [
     "/src/pysm3",
 ]
-packages = [
-    "src/pysm3",
-]
 
 [tool.hatch.build.targets.wheel]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ version-file = "src/pysm3/_version.py"
 
 [tool.hatch.build.targets.sdist]
 include = [
-    "/src/pysm3",
+    "/src/pysm3/**",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -103,6 +103,9 @@ include = [
 packages = [
     "src/pysm3",
 ]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/pysm3/data/presets.cfg" = "pysm3/data/presets.cfg"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ docs = [
     "ipykernel",
     "matplotlib",
     "nbsphinx",
-    "pandoc",
     "sphinx-pyproject",
     "sphinx-astropy",
     "sphinx-math-dollar",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,6 @@ packages = [
     "src/pysm3",
 ]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/pysm3/data/presets.cfg" = "pysm3/data/presets.cfg"
-
 [tool.pytest.ini_options]
 filterwarnings = [
     'ignore:may indicate binary incompatibility:RuntimeWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ include = [
     "/src/pysm3/**",
 ]
 
+[tool.hatch.build.targets.sdist.force-include]
+"src/pysm3/data/presets.cfg" = "src/pysm3/data/presets.cfg"
+
 [tool.hatch.build.targets.wheel]
 include = [
     "/src/pysm3/**",


### PR DESCRIPTION
This PR cleans up a set of packaging issues that showed up during release prep and artifact verification. Each fix is isolated in its own commit for easier review.

Included changes:
- remove the stale Python 3.8 classifier to match `requires-python >=3.9`
- remove the dead `importlib_metadata` conditional dependency
- update the release instructions to install `.[test]` before running `pytest`
- remove stale Python `pandoc` package entries from docs dependencies
- preserve the `src/` layout in sdists so `hatch-vcs` can write `src/pysm3/_version.py`
- remove the redundant wheel `force-include` that broke wheel builds from sdists
- fix README RST markup so the long description renders on PyPI

Verification:
- `python -m build`
- `python -m twine check dist/*`