### PR TITLE
Relax scipy upper bound, require healpy >= 1.18.1

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         include:
 
-           - name: Python 3.9
+           - name: Python 3.10
              os: ubuntu-22.04
-             python: 3.9
+             python: 3.10
 
            - name: Python 3.12
              os: ubuntu-22.04

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -26,7 +26,7 @@ jobs:
 
            - name: Python 3.10
              os: ubuntu-22.04
-             python: 3.10
+             python: "3.10"
 
            - name: Python 3.12
              os: ubuntu-22.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ maintainers = [
 dependencies = [
     "astropy",
     "h5py",
-    "scipy >= 1.10, < 1.15",
-    "healpy >= 1.16.0",
+    "scipy >= 1.10",
+    "healpy >= 1.18.1",
     "numba",
     "numpy >= 1.21",
     "toml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 description = "PySM generates full-sky simulations of Galactic emissions in intensity and polarization"
 readme = "README.rst"
 license.file = "LICENSE"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = [
     "cmb",
     "galactic-foregrounds",
@@ -37,8 +37,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
The `scipy < 1.15` pin was a workaround for healpy [#987](https://github.com/healpy/healpy/issues/987) (`map2alm_lsq` shape error with scipy 1.15+). That bug was fixed in [healpy PR #991](https://github.com/healpy/healpy/pull/991) and released in healpy 1.18.1.

This PR:
- Removes the `scipy < 1.15` upper bound (keeps `scipy >= 1.10` minimum)
- Bumps healpy minimum from 1.16.0 to 1.18.1 to ensure the fix is present
- Unblocks Python 3.14 support for downstream packages

Closes #216

Requested by @ziotom78 in https://github.com/galsci/pysm/issues/216