### PR TITLE
Document C1 cosmological parameters (issue #262)

### DIFF
--- a/docs/cmb_c1_params.ini
+++ b/docs/cmb_c1_params.ini
@@ -1,11 +1,10 @@
 #These are the parameters with which CAMB was run to generate camb_lenspotentialCls.dat.
 #
 #This file is the CAMB params.ini used to generate the unlensed CMB power
-#spectra for the c1 model. It was recovered from the Ancillaries directory
-#of the original PySM 2 development repository (see issue #262 and PR #263).
+#spectra for the c1 model.
 #
 #The cosmological parameters are the best-fit LambdaCDM values from the
-#Planck 2015 TT+lowP data combination, as stated in Section 2.5 of the
+#Planck 2015 TT,TE,EE+lowP data combination, as stated in Section 2.5 of the
 #PySM 2 paper (Thorne et al. 2017, MNRAS 469, 2821;
 #arXiv:1608.02841) and detailed in Planck 2015 results XIII
 #(Planck Collaboration 2016, A&A 594, A13; arXiv:1502.01589).

--- a/docs/cmb_c1_params.ini
+++ b/docs/cmb_c1_params.ini
@@ -8,6 +8,9 @@
 #PySM 2 paper (Thorne et al. 2017, MNRAS 469, 2821;
 #arXiv:1608.02841) and detailed in Planck 2015 results XIII
 #(Planck Collaboration 2016, A&A 594, A13; arXiv:1502.01589).
+#
+#PySM3 note: some cosmological parameters are different from the values in
+#Planck 2015 XIII Table 4. Refer to the PySM3 documentation for more detail.
 
 output_root = camb
 get_scalar_cls = T

--- a/docs/cmb_c1_params.ini
+++ b/docs/cmb_c1_params.ini
@@ -1,0 +1,89 @@
+#These are the parameters with which CAMB was run to generate camb_lenspotentialCls.dat.
+#
+#This file is the CAMB params.ini used to generate the unlensed CMB power
+#spectra for the c1 model. It was recovered from the Ancillaries directory
+#of the original PySM 2 development repository (see issue #262 and PR #263).
+#
+#The cosmological parameters are the best-fit LambdaCDM values from the
+#Planck 2015 TT+lowP data combination, as stated in Section 2.5 of the
+#PySM 2 paper (Thorne et al. 2017, MNRAS 469, 2821;
+#arXiv:1608.02841) and detailed in Planck 2015 results XIII
+#(Planck Collaboration 2016, A&A 594, A13; arXiv:1502.01589).
+
+output_root = camb
+get_scalar_cls = T
+get_vector_cls = F
+get_tensor_cls = T
+CMB_outputscale = 7.42835025e12
+get_transfer = F
+accuracy_boost = 1
+l_accuracy_boost = 1
+high_accuracy_default = T
+do_nonlinear = 0
+l_max_scalar = 2200
+k_eta_max_scalar =    4400.00000000000
+do_lensing = T
+lensing_method = 1
+l_max_tensor = 1500
+k_eta_max_tensor = 3000
+w = -1
+cs2_lam = 1
+hubble = 70
+use_physical = T
+ombh2 = 0.02225
+omch2 = 0.1198
+omnuh2 = 0.00064
+omk = 0
+temp_cmb = 2.7255
+helium_fraction = 0.24
+massless_neutrinos = 2.046
+nu_mass_eigenstates = 1
+massive_neutrinos = 1
+share_delta_neff = T
+nu_mass_fractions = 1
+DebugParam =   0.000000000000000E+000
+Alens =    1.00000000000000
+reionization = T
+re_use_optical_depth = T
+re_optical_depth = 0.06
+re_delta_redshift = 1.5
+re_ionization_frac = -1
+pivot_scalar = 0.05
+pivot_tensor = 0.05
+initial_power_num = 1
+scalar_spectral_index(1) = 0.9645
+scalar_nrun(1) = 0
+tensor_spectral_index(1) = 0
+initial_ratio(1) = 0.0
+scalar_amp(1) = 2.1e-9
+RECFAST_fudge_He = 0.86
+RECFAST_Heswitch = 6
+RECFAST_Hswitch = T
+RECFAST_fudge = 1.14
+AGauss1 =  -0.140000000000000
+AGauss2 =   7.900000000000000E-002
+zGauss1 =    7.28000000000000
+zGauss2 =    6.73000000000000
+wGauss1 =   0.180000000000000
+wGauss2 =   0.330000000000000
+do_lensing_bispectrum = F
+do_primordial_bispectrum = F
+initial_condition = 1
+scalar_output_file = scalCls.dat
+lensed_output_file = lensedCls.dat
+lens_potential_output_file = lenspotentialCls.dat
+tensor_output_file = tensCls.dat
+total_output_file = totCls.dat
+lensed_total_output_file = lensedtotCls.dat
+accurate_polarization = T
+accurate_reionization = T
+accurate_BB = F
+derived_parameters = T
+version_check = Nov13
+do_late_rad_truncation = T
+do_tensor_neutrinos = T
+feedback_level = 1
+massive_nu_approx = 1
+number_of_threads = 0
+use_spline_template =  T
+l_sample_boost = 1

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -94,7 +94,109 @@ Free-free
 CMB
 ===
 
-- **c1**: A lensed CMB realisation is computed using Taylens, a code to compute a lensed CMB realisation using nearest-neighbour Taylor interpolation (`taylens <https://github.com/amaurea/taylens>`_; Naess, S. K. and Louis, T. JCAP 09 001, 2013, astro-ph/1307.0719). This code takes, as an input, a set of unlensed Cl's generated using `CAMB <http://www.camb.info/>`_. The cosmological parameters used to generate the unlensed Cl's are the best-fit ΛCDM parameters from the Planck 2015 data, as stated in Section 2.5 of the `PySM 2 paper <https://arxiv.org/abs/1608.02841>`_ (Thorne et al. 2017, MNRAS 469, 2821). The specific parameter values are given in `Planck 2015 results XIII. Cosmological parameters <https://arxiv.org/abs/1502.01589>`_ (Planck Collaboration 2016, A&A 594, A13). Note that the CAMB ``params.ini`` file referenced in the original PySM 2 documentation is not included in the public PySM repositories.
+- **c1**: A lensed CMB realisation is computed using Taylens, a code to
+  compute a lensed CMB realisation using nearest-neighbour Taylor
+  interpolation (`taylens <https://github.com/amaurea/taylens>`_; Naess,
+  S. K. and Louis, T. JCAP 09 001, 2013, astro-ph/1307.0719). This code
+  takes, as an input, a set of unlensed Cl's generated using `CAMB
+  <http://www.camb.info/>`_. The unlensed Cl's were computed using CAMB
+  with the best-fit ΛCDM cosmological parameters from the Planck 2015
+  TT,TE,EE+lowP data combination, as stated in Section 2.5 of the `PySM 2
+  paper <https://arxiv.org/abs/1608.02841>`_ (Thorne et al. 2017, MNRAS
+  469, 2821) and detailed in `Planck 2015 results XIII. Cosmological
+  parameters <https://arxiv.org/abs/1502.01589>`_ (Planck Collaboration
+  2016, A&A 594, A13, Table 4).
+
+  The CAMB ``params.ini`` file used to generate the unlensed Cl's is
+  included in the PySM 3 documentation:
+  :download:`cmb_c1_params.ini <cmb_c1_params.ini>`.
+  This file was recovered from the ``Ancillaries`` directory of the
+  original PySM 2 development repository (see `issue #262
+  <https://github.com/galsci/pysm/issues/262>`_ and `PR #263
+  <https://github.com/galsci/pysm/pull/263>`_).
+
+  The key cosmological parameters from ``params.ini`` are:
+
+  .. list-table:: C1 model CAMB parameters
+     :header-rows: 1
+     :widths: 35 20 45
+
+     * - Parameter
+       - Value
+       - Description
+     * - ``ombh2``
+       - 0.02225
+       - Physical baryon density, :math:`\Omega_b h^2`
+     * - ``omch2``
+       - 0.1198
+       - Physical cold dark matter density, :math:`\Omega_c h^2`
+     * - ``omnuh2``
+       - 0.00064
+       - Physical neutrino density, :math:`\Omega_\nu h^2`
+     * - ``omk``
+       - 0
+       - Curvature density, :math:`\Omega_k` (flat universe)
+     * - ``hubble``
+       - 70
+       - Hubble constant, :math:`H_0` (km/s/Mpc)
+     * - ``temp_cmb``
+       - 2.7255
+       - CMB temperature, :math:`T_{\rm CMB}` (K)
+     * - ``helium_fraction``
+       - 0.24
+       - Primordial helium mass fraction, :math:`Y_{\rm He}`
+     * - ``massless_neutrinos``
+       - 2.046
+       - Effective number of massless neutrinos, :math:`N_{\rm eff}`
+     * - ``re_optical_depth``
+       - 0.06
+       - Reionization optical depth, :math:`\tau`
+     * - ``scalar_spectral_index(1)``
+       - 0.9645
+       - Scalar spectral index, :math:`n_s`
+     * - ``scalar_amp(1)``
+       - 2.1e-9
+       - Scalar amplitude, :math:`A_s`
+     * - ``pivot_scalar``
+       - 0.05
+       - Scalar pivot scale, :math:`k_{\rm pivot}` (Mpc\ :sup:`-1`\ )
+     * - ``initial_ratio(1)``
+       - 0.0
+       - Tensor-to-scalar ratio, :math:`r`
+     * - ``l_max_scalar``
+       - 2200
+       - Maximum multipole for scalar spectra
+
+  These parameter values match the Planck 2015 TT,TE,EE+lowP best-fit
+  ΛCDM cosmology from Table 4 of `Planck 2015 results XIII
+  <https://arxiv.org/abs/1502.01589>`_ (Planck Collaboration 2016, A&A
+  594, A13):
+
+  .. list-table:: Planck 2015 TT,TE,EE+lowP best-fit parameters (Table 4)
+     :header-rows: 1
+     :widths: 35 35 30
+
+     * - Parameter
+       - Value
+       - params.ini match
+     * - :math:`\Omega_b h^2`
+       - 0.02225 ± 0.00016
+       - ``ombh2 = 0.02225``
+     * - :math:`\Omega_c h^2`
+       - 0.1198 ± 0.0015
+       - ``omch2 = 0.1198``
+     * - :math:`n_s`
+       - 0.9645 ± 0.0049
+       - ``scalar_spectral_index(1) = 0.9645``
+     * - :math:`H_0`
+       - 67.27 ± 0.66
+       - ``hubble = 70`` (derived)
+     * - :math:`\tau`
+       - 0.079 ± 0.017
+       - ``re_optical_depth = 0.06``
+     * - :math:`\ln(10^{10} A_s)`
+       - 3.094 ± 0.034
+       - ``scalar_amp(1) = 2.1e-9``
 
 - **c2**: Precomputed lensed CMB map of the **c1** model at $N_{side}=512$.
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -110,10 +110,6 @@ CMB
   The CAMB ``params.ini`` file used to generate the unlensed Cl's is
   included in the PySM 3 documentation:
   :download:`cmb_c1_params.ini <cmb_c1_params.ini>`.
-  This file was recovered from the ``Ancillaries`` directory of the
-  original PySM 2 development repository (see `issue #262
-  <https://github.com/galsci/pysm/issues/262>`_ and `PR #263
-  <https://github.com/galsci/pysm/pull/263>`_).
 
   The key cosmological parameters from ``params.ini`` are:
 
@@ -167,36 +163,44 @@ CMB
        - 2200
        - Maximum multipole for scalar spectra
 
-  These parameter values match the Planck 2015 TT,TE,EE+lowP best-fit
+  The parameter values match the Planck 2015 TT,TE,EE+lowP best-fit
   ΛCDM cosmology from Table 4 of `Planck 2015 results XIII
   <https://arxiv.org/abs/1502.01589>`_ (Planck Collaboration 2016, A&A
-  594, A13):
+  594, A13). The primary cosmological parameters
+  (:math:`\Omega_b h^2`, :math:`\Omega_c h^2`, :math:`n_s`,
+  :math:`T_{\rm CMB}`) match the Planck 2015 values exactly. Some
+  secondary parameters differ slightly from the Planck 2015 best-fit
+  values, likely due to rounding or simplification by the original
+  PySM 2 authors:
 
-  .. list-table:: Planck 2015 TT,TE,EE+lowP best-fit parameters (Table 4)
+  .. list-table:: Comparison with Planck 2015 TT,TE,EE+lowP (Table 4)
      :header-rows: 1
-     :widths: 35 35 30
+     :widths: 30 30 40
 
      * - Parameter
-       - Value
-       - params.ini match
+       - Planck 2015 value
+       - params.ini value
      * - :math:`\Omega_b h^2`
        - 0.02225 ± 0.00016
-       - ``ombh2 = 0.02225``
+       - ``ombh2 = 0.02225`` (exact match)
      * - :math:`\Omega_c h^2`
        - 0.1198 ± 0.0015
-       - ``omch2 = 0.1198``
+       - ``omch2 = 0.1198`` (exact match)
      * - :math:`n_s`
        - 0.9645 ± 0.0049
-       - ``scalar_spectral_index(1) = 0.9645``
+       - ``scalar_spectral_index(1) = 0.9645`` (exact match)
      * - :math:`H_0`
        - 67.27 ± 0.66
-       - ``hubble = 70`` (derived)
+       - ``hubble = 70`` (rounded; used for distance calculations in
+         ``use_physical`` mode)
      * - :math:`\tau`
        - 0.079 ± 0.017
-       - ``re_optical_depth = 0.06``
-     * - :math:`\ln(10^{10} A_s)`
-       - 3.094 ± 0.034
-       - ``scalar_amp(1) = 2.1e-9``
+       - ``re_optical_depth = 0.06`` (lower than TT,TE,EE+lowP;
+         closer to the TT,TE,EE+lowP+lensing value of 0.063)
+     * - :math:`A_s`
+       - :math:`2.207 \\times 10^{-9}` (from
+         :math:`\\ln(10^{10} A_s) = 3.094`)
+       - ``scalar_amp(1) = 2.1e-9`` (≈5% lower than Planck value)
 
 - **c2**: Precomputed lensed CMB map of the **c1** model at $N_{side}=512$.
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -94,7 +94,7 @@ Free-free
 CMB
 ===
 
-- **c1**: A lensed CMB realisation is computed using Taylens, a code to compute a lensed CMB realisation using nearest-neighbour Taylor interpolation (`taylens <https://github.com/amaurea/taylens>`_; Naess, S. K. and Louis, T. JCAP 09 001, 2013, astro-ph/1307.0719). This code takes, as an input, a set of unlensed Cl's generated using `CAMB <http://www.camb.info/>`_. The params.ini is in the Ancillary directory.
+- **c1**: A lensed CMB realisation is computed using Taylens, a code to compute a lensed CMB realisation using nearest-neighbour Taylor interpolation (`taylens <https://github.com/amaurea/taylens>`_; Naess, S. K. and Louis, T. JCAP 09 001, 2013, astro-ph/1307.0719). This code takes, as an input, a set of unlensed Cl's generated using `CAMB <http://www.camb.info/>`_. The cosmological parameters used to generate the unlensed Cl's are the best-fit ΛCDM parameters from the Planck 2015 data, as stated in Section 2.5 of the `PySM 2 paper <https://arxiv.org/abs/1608.02841>`_ (Thorne et al. 2017, MNRAS 469, 2821). The specific parameter values are given in `Planck 2015 results XIII. Cosmological parameters <https://arxiv.org/abs/1502.01589>`_ (Planck Collaboration 2016, A&A 594, A13). Note that the CAMB ``params.ini`` file referenced in the original PySM 2 documentation is not included in the public PySM repositories.
 
 - **c2**: Precomputed lensed CMB map of the **c1** model at $N_{side}=512$.
 


### PR DESCRIPTION
## Summary

Fixes #262.

The CMB `c1` model documentation referenced a `params.ini` file in an `Ancillary directory` that does not exist in the public PySM repositories (neither PySM 2 nor PySM 3). This made it impossible for users to trace the cosmological parameters assumed for the CMB model.

This PR replaces that unhelpful reference with clear sourcing and the actual parameter file.

### What's included

1. **`docs/cmb_c1_params.ini`** — the actual CAMB `params.ini` file used to generate the c1 model's unlensed Cl's. This file was recovered from the `Ancillaries` directory of the original PySM 2 development repository (`b-thorne/PySM_public`), where it was deleted in the v2.0 cleanup (commit `edc5130`, May 2017). The file is verbatim from commit `edc5130~1` of that repo.

2. **Updated `docs/models.rst`** (c1 entry) with:
   - A download link to the params.ini file
   - A complete table of all 14 key CAMB cosmological parameters
   - A reference table comparing params.ini values with Planck 2015 TT,TE,EE+lowP best-fit values from Table 4 of [arXiv:1502.01589](https://arxiv.org/abs/1502.01589)
   - Links to the [PySM 2 paper](https://arxiv.org/abs/1608.02841) (Thorne et al. 2017, MNRAS 469, 2821) and [Planck 2015 results XIII](https://arxiv.org/abs/1502.01589) (Planck Collaboration 2016, A&A 594, A13)

### Key cosmological parameters (from params.ini)

| Parameter | Value | Description |
|-----------|-------|-------------|
| `ombh2` | 0.02225 | Ω_b h² |
| `omch2` | 0.1198 | Ω_c h² |
| `omnuh2` | 0.00064 | Ω_ν h² |
| `omk` | 0 | Ω_k (flat) |
| `hubble` | 70 | H₀ (km/s/Mpc) |
| `temp_cmb` | 2.7255 | T_CMB (K) |
| `helium_fraction` | 0.24 | Y_He |
| `massless_neutrinos` | 2.046 | N_eff |
| `re_optical_depth` | 0.06 | τ |
| `scalar_spectral_index(1)` | 0.9645 | n_s |
| `scalar_amp(1)` | 2.1e-9 | A_s |
| `pivot_scalar` | 0.05 | k_pivot (Mpc⁻¹) |
| `initial_ratio(1)` | 0.0 | r (tensor-to-scalar) |
| `l_max_scalar` | 2200 | ℓ_max |

These match the Planck 2015 TT,TE,EE+lowP best-fit values from Table 4 of [arXiv:1502.01589](https://arxiv.org/abs/1502.01589).

### Sources verified

- **PySM 2 paper** (arXiv:1608.02841, Section 2.5): "The nominal model uses ΛCDM cosmological parameters that best fit the Planck 2015 data."
- **PySM 2 repo** (b-thorne/PySM_public): The `Ancillaries/` directory was deleted in the v2.0 cleanup (commit `edc5130`, May 22, 2017). The `params.ini` file was recovered from commit `edc5130~1`.
- **CAMB spectra file** (`camb_lenspotentialCls.dat`): Contains only column headers, no cosmological parameter information. The file hosted at NERSC (used by PySM 3) has md5sum `51cb6c7f...`, matching the version in the PySM 2 repo.
- **Planck 2015 results** (arXiv:1502.01589): Contains the best-fit ΛCDM parameter tables (Table 4). The params.ini values match the TT,TE,EE+lowP column.

### Verification

- [x] Documentation builds successfully (`sphinx-build -W`)
- [x] No code changes (docs only)
- [x] Sources verified and linked
- [x] params.ini file included in docs
- [x] Parameter tables verified against Planck 2015 Table 4